### PR TITLE
Fix small typo in ticket overview page

### DIFF
--- a/Ombi.UI/Views/Issues/Details.cshtml
+++ b/Ombi.UI/Views/Issues/Details.cshtml
@@ -57,7 +57,7 @@
             <div><strong>Type:</strong> @StringHelper.ToCamelCaseWords(issue.Issue.ToString())</div>
             <div><strong>User Reported:</strong> @issue.UserReported</div>
             <div><strong>User Note:</strong> @issue.UserNote</div>
-            <div><strong>Admin Note:</strong>@issue.AdminNote</div>
+            <div><strong>Admin Note:</strong> @issue.AdminNote</div>
         </div>
         @if (isAdmin)
         {


### PR DESCRIPTION
Just a small change to put a space between the colon and the admin message to fix:

<img width="262" alt="screen shot 2016-12-27 at 19 26 21" src="https://cloud.githubusercontent.com/assets/17162399/21506730/673585f0-cc6a-11e6-9dbc-e2718d94be0a.png">

Untested but such a small change I cannot see it breaking anything.