### PR TITLE
Added permission to see who made requests.

### DIFF
--- a/Ombi.Core/SettingModels/UserManagementSettings.cs
+++ b/Ombi.Core/SettingModels/UserManagementSettings.cs
@@ -38,6 +38,7 @@ namespace Ombi.Core.SettingModels
         public bool UsersCanViewOnlyOwnRequests { get; set; }
         public bool UsersCanViewOnlyOwnIssues { get; set; }
         public bool BypassRequestLimit { get; set; }
+        public bool ViewUsers { get; set; }
 
         // Features
         public bool RecentlyAddedNotification { get; set; }

--- a/Ombi.Helpers/Permissions/Permissions.cs
+++ b/Ombi.Helpers/Permissions/Permissions.cs
@@ -73,6 +73,9 @@ namespace Ombi.Helpers.Permissions
         UsersCanViewOnlyOwnIssues = 2048,
 
         [Display(Name = "Bypass the request limit")]
-        BypassRequestLimit = 4096
+        BypassRequestLimit = 4096,
+
+        [Display(Name = "User can see who requested")]
+        ViewUsers = 8192
     }
 }

--- a/Ombi.UI/Modules/RequestsModule.cs
+++ b/Ombi.UI/Modules/RequestsModule.cs
@@ -164,6 +164,8 @@ namespace Ombi.UI.Modules
 
            
             var canManageRequest = Security.HasAnyPermissions(User, Permissions.Administrator, Permissions.ManageRequests);
+            var allowViewUsers = Security.HasAnyPermissions(User, Permissions.Administrator, Permissions.ViewUsers);
+
             var viewModel = dbMovies.Select(movie => new RequestViewModel
             {
                 ProviderId = movie.ProviderId,
@@ -180,7 +182,7 @@ namespace Ombi.UI.Modules
                 Approved = movie.Available || movie.Approved,
                 Title = movie.Title,
                 Overview = movie.Overview,
-                RequestedUsers = canManageRequest ? movie.AllUsers.ToArray() : new string[] { },
+                RequestedUsers = canManageRequest || allowViewUsers ? movie.AllUsers.ToArray() : new string[] { },
                 ReleaseYear = movie.ReleaseDate.Year.ToString(),
                 Available = movie.Available,
                 Admin = canManageRequest,
@@ -247,6 +249,8 @@ namespace Ombi.UI.Modules
 
 
             var canManageRequest = Security.HasAnyPermissions(User, Permissions.Administrator, Permissions.ManageRequests);
+            var allowViewUsers = Security.HasAnyPermissions(User, Permissions.Administrator, Permissions.ViewUsers);
+
             var viewModel = dbTv.Select(tv => new RequestViewModel
             {
                 ProviderId = tv.ProviderId,
@@ -263,7 +267,7 @@ namespace Ombi.UI.Modules
                 Approved = tv.Available || tv.Approved,
                 Title = tv.Title,
                 Overview = tv.Overview,
-                RequestedUsers = canManageRequest ? tv.AllUsers.ToArray() : new string[] { },
+                RequestedUsers = canManageRequest || allowViewUsers ? tv.AllUsers.ToArray() : new string[] { },
                 ReleaseYear = tv.ReleaseDate.Year.ToString(),
                 Available = tv.Available,
                 Admin = canManageRequest,

--- a/Ombi.UI/Views/UserManagementSettings/UserManagementSettings.cshtml
+++ b/Ombi.UI/Views/UserManagementSettings/UserManagementSettings.cshtml
@@ -1,4 +1,4 @@
-﻿@using Ombi.UI.Helpers
+@using Ombi.UI.Helpers
 @inherits Nancy.ViewEngines.Razor.NancyRazorViewBase<Ombi.Core.SettingModels.UserManagementSettings>
 @Html.Partial("Shared/Partial/_Sidebar")
 
@@ -25,6 +25,7 @@
             @Html.Checkbox(Model.UsersCanViewOnlyOwnIssues, "UsersCanViewOnlyOwnIssues", "Users can only view their own issues")
             @Html.Checkbox(Model.UsersCanViewOnlyOwnRequests, "UsersCanViewOnlyOwnRequests", "Users can only view their own requests")
             @Html.Checkbox(Model.BypassRequestLimit, "BypassRequestLimit", "Bypass the request limit")
+            @Html.Checkbox(Model.ViewUsers, "ViewUsers", "User can see who made requests")
 
 
 


### PR DESCRIPTION
I've created a user permission that allows non-admins to see who made the requests.

If the site is configured to allow login without a password, this will expose how to log in as other users, but I don't think that should be a consideration.