### PR TITLE
Fixing #1236  the broken  link "view in plex" button.

### DIFF
--- a/Ombi.Helpers/PlexHelper.cs
+++ b/Ombi.Helpers/PlexHelper.cs
@@ -99,7 +99,7 @@ namespace Ombi.Helpers
         public static string GetPlexMediaUrl(string machineId, string mediaId)
         {
             var url =
-                $"https://app.plex.tv/web/app#!/server/{machineId}/details/%2Flibrary%2Fmetadata%2F{mediaId}";
+                $"https://app.plex.tv/web/app#!/server/{machineId}/details?key=library%2Fmetadata%2F{mediaId}";
             return url;
         }
 


### PR DESCRIPTION
Fixing the broken link to app.plex.tv for the "view in plex" button

Fix for: #1236