### PR TITLE
Add placeholders to search inputs

### DIFF
--- a/Ombi.UI/Views/Search/Index.cshtml
+++ b/Ombi.UI/Views/Search/Index.cshtml
@@ -59,7 +59,7 @@
             <!-- Movie tab -->
             <div role="tabpanel" class="tab-pane active" id="MoviesTab">
                 <div class="input-group">
-                    <input id="movieSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons">
+                    <input id="movieSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons" placeholder="Enter search term...">
                     <div class="input-group-addon">
                         <div class="btn-group">
                             <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -85,7 +85,7 @@
                         <!-- Actors tab -->
                 <div role="tabpanel" class="tab-pane" id="ActorsTab">
                     <div class="input-group">
-                        <input id="actorSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons">
+                        <input id="actorSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons" placeholder="Enter search term...">
                         <div class="input-group-addon">
                             <i id="actorSearchButton" class="fa fa-search"></i>
                         </div>
@@ -108,7 +108,7 @@
     <!-- TV tab -->
             <div role="tabpanel" class="tab-pane" id="TvShowTab">
                 <div class="input-group">
-                    <input id="tvSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons">
+                    <input id="tvSearchContent" type="text" class="form-control form-control-custom form-control-search form-control-withbuttons" placeholder="Enter search term...">
                     <div class="input-group-addon">
                         <div class="btn-group">
                             <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
@@ -137,7 +137,7 @@
             <!-- Music tab -->
             <div role="tabpanel" class="tab-pane" id="MusicTab">
                 <div class="input-group">
-                    <input id="musicSearchContent" type="text" class="form-control form-control-custom form-control-search">
+                    <input id="musicSearchContent" type="text" class="form-control form-control-custom form-control-search" placeholder="Enter search term...">
                     <div class="input-group-addon">
                         <i id="musicSearchButton" class="fa fa-search"></i>
                     </div>


### PR DESCRIPTION
iOS doesn't support input autofocusing (or the jQuery `focus()` event) so when you open the search screen, there's no indicator for what happens next.

I tried clicking the magnifying glass to bring up a search box - this adds placeholders so the user knows where to tap.

Before:
<a href="https://user-images.githubusercontent.com/430255/27756842-d6855f24-5dc0-11e7-8dff-9836c9718cde.jpg" target="_blank"><img src="https://user-images.githubusercontent.com/430255/27756842-d6855f24-5dc0-11e7-8dff-9836c9718cde.jpg" alt="img_2915" width="320" style="max-width:100%;"></a>

After:
<a href="https://user-images.githubusercontent.com/430255/27756844-dee07794-5dc0-11e7-85d9-40db1cedcfa3.jpg" target="_blank"><img src="https://user-images.githubusercontent.com/430255/27756844-dee07794-5dc0-11e7-85d9-40db1cedcfa3.jpg" alt="img_2916" width="320" style="max-width:100%;"></a>