### PR TITLE
This adds two fields to the Email Notifications settings page. 

### DIFF
--- a/src/Ombi.Notifications/GenericEmailProvider.cs
+++ b/src/Ombi.Notifications/GenericEmailProvider.cs
@@ -47,10 +47,30 @@ namespace Ombi.Notifications
                 message.From.Add(new MailboxAddress(settings.SenderAddress, settings.SenderAddress));
                 message.To.Add(new MailboxAddress(model.To, model.To));
 
+                
+
+
                 using (var client = new SmtpClient())
                 {
-                    client.Connect(settings.Host, settings.Port); // Let MailKit figure out the correct SecureSocketOptions.
+                    if (settings.DisableCertificateChecking)
+                    {
+                        // Disable validation of the certificate associated with the SMTP service
+                        // Helpful when the TLS certificate is not in the certificate store of the server
+                        // Does carry the risk of man in the middle snooping
+                        client.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => true;
+                    }
 
+                    if (settings.DisableTLS)
+                    {
+                        // Does not attempt to use either TLS or SSL
+                        // Helpful when MailKit finds a TLS certificate, but it unable to use it
+                        client.Connect(settings.Host, settings.Port, MailKit.Security.SecureSocketOptions.None); 
+                    }
+                    else
+                    {
+                        client.Connect(settings.Host, settings.Port); // Let MailKit figure out the correct SecureSocketOptions.
+                    }
+                    
                     // Note: since we don't have an OAuth2 token, disable
                     // the XOAUTH2 authentication mechanism.
                     client.AuthenticationMechanisms.Remove("XOAUTH2");
@@ -92,7 +112,19 @@ namespace Ombi.Notifications
 
                 using (var client = new SmtpClient())
                 {
-                    client.Connect(settings.Host, settings.Port); // Let MailKit figure out the correct SecureSocketOptions.
+                    if (settings.DisableCertificateChecking)
+                    {
+                        client.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => true;
+                    }
+
+                    if (settings.DisableTLS)
+                    {
+                        client.Connect(settings.Host, settings.Port, MailKit.Security.SecureSocketOptions.None);
+                    }
+                    else
+                    {
+                        client.Connect(settings.Host, settings.Port); // Let MailKit figure out the correct SecureSocketOptions.
+                    }
 
                     // Note: since we don't have an OAuth2 token, disable
                     // the XOAUTH2 authentication mechanism.

--- a/src/Ombi.Settings/Settings/Models/Notifications/EmailNotificationSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/Notifications/EmailNotificationSettings.cs
@@ -11,5 +11,7 @@
         public string Username { get; set; }
         public bool Authentication { get; set; }
         public string AdminEmail { get; set; }
+        public bool DisableTLS { get; set; }
+        public bool DisableCertificateChecking { get; set; }
     }
 }

--- a/src/Ombi/ClientApp/app/interfaces/INotificationSettings.ts
+++ b/src/Ombi/ClientApp/app/interfaces/INotificationSettings.ts
@@ -13,6 +13,8 @@ export interface IEmailNotificationSettings extends INotificationSettings {
     username: string;
     authentication: boolean;
     adminEmail: string;
+    disableTLS: boolean;
+    disableCertificateChecking: boolean;
     notificationTemplates: INotificationTemplates[];
 }
 

--- a/src/Ombi/ClientApp/app/settings/notifications/emailnotification.component.html
+++ b/src/Ombi/ClientApp/app/settings/notifications/emailnotification.component.html
@@ -18,6 +18,18 @@
                         <input type="checkbox" id="Authentication" formControlName="authentication"><label for="Authentication">Enable SMTP Authentication</label>
                     </div>
                 </div>
+
+                <div class="form-group">
+                    <div class="checkbox">
+                            <input type="checkbox" id="disableTLS" formControlName="disableTLS"><label for="disableTLS">Disable TLS/SSL</label>
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <div class="checkbox">
+                        <input type="checkbox" id="disableCertificateChecking" formControlName="disableCertificateChecking"><label for="disableCertificateChecking">Disable Certificate Checking</label>
+                    </div>
+                </div>
                 <div class="form-group">
                     <label for="host" class="control-label">SMTP Host</label>
                   

--- a/src/Ombi/ClientApp/app/settings/notifications/emailnotification.component.ts
+++ b/src/Ombi/ClientApp/app/settings/notifications/emailnotification.component.ts
@@ -35,6 +35,8 @@ export class EmailNotificationComponent implements OnInit {
                 senderName: [x.senderName],
                 username: [x.username],
                 adminEmail: [x.adminEmail, [Validators.required, Validators.email]],
+                disableTLS: [x.disableTLS],
+                disableCertificateChecking: [x.disableCertificateChecking],
             });
 
             if (x.authentication) {


### PR DESCRIPTION
It allows for the disabling of TLS/SSL as well as the ability to disable certificate validation when sending notification emails.