### PR TITLE
Fix "content length error" on preview gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Search the existing requests to see if your suggestion has already been submitte
 
 # Preview
 
-![Preview](http://i.imgur.com/rTBEt6K.gif)
+![Preview](http://i.imgur.com/Nn1BwAM.gif)
 
 # Installation
 


### PR DESCRIPTION
Former gif exceed the limit on external ressourceses in the github readme - I did not know that. Hehe, my bad!
The gif has been resized and optimized.