### PR TITLE
 Fix duplicated "Requests" element ID on new Issues link

### DIFF
--- a/src/Ombi/ClientApp/app/app.component.html
+++ b/src/Ombi/ClientApp/app/app.component.html
@@ -35,7 +35,7 @@
                     </li>
                 </ul>
                 <ul *ngIf="issuesEnabled" class="nav navbar-nav">
-                    <li id="Requests" [routerLinkActive]="['active']">
+                    <li id="Issues" [routerLinkActive]="['active']">
                         <a [routerLink]="['/issues']">
                             <i class="fa fa-exclamation-circle"></i> {{ 'NavigationBar.Issues' | translate }}</a>
                     </li>


### PR DESCRIPTION
Issues link currently has the same element ID as the Requests link. This makes styling hard, and it doesn't seem intended anyway.