### PR TITLE
Fix user mentions in Slack notifications

### DIFF
--- a/src/Ombi.Api.Slack/SlackApi.cs
+++ b/src/Ombi.Api.Slack/SlackApi.cs
@@ -23,6 +23,7 @@ namespace Ombi.Api.Slack
             body.channel = message.channel;
             body.text = message.text;
             body.username = message.username;
+            body.link_names = 1;
 
             if (!string.IsNullOrEmpty(message.icon_url))
             {


### PR DESCRIPTION
Adding link_names parameter to ensure that incoming webhooks get properly parsed for user mentions. Without this user mentions remain as plain text.