### PR TITLE
Add plain password for emby login

### DIFF
--- a/src/Ombi.Api.Emby/EmbyApi.cs
+++ b/src/Ombi.Api.Emby/EmbyApi.cs
@@ -51,6 +51,7 @@ namespace Ombi.Api.Emby
             var body = new
             {
                 username,
+                pw = password,
                 password = password.GetSha1Hash().ToLower(),
                 passwordMd5 = password.CalcuateMd5Hash()
             };


### PR DESCRIPTION
I am unable to access Ombi with my emby connect account. I've got a 401.
I had the same problem with a Kodi addon. It is stated in the [emby authentication docs](https://github.com/MediaBrowser/Emby/wiki/Authentication#authenticating-a-user) that we are supposed to provide 3 fields for the password: *plain*, *md5*, and *sha1*.
Actually it seems that the only required field in the future will be the plain password one.
I have no idea why they would need the plain password, it's pretty bad pratice to send it in clear even over HTTPS but otherwise I can't login.
My emby account is pretty old, maybe that's why it's stored plain ?
Anyway I added the missing *pw* field to the login request. It should work just fine now.

PS: We should at least check if https is enabled before using this field IMO.
