### PR TITLE
Css fixes

### DIFF
--- a/src/Ombi/ClientApp/styles/Themes/plex.scss
+++ b/src/Ombi/ClientApp/styles/Themes/plex.scss
@@ -1,5 +1,4 @@
-﻿@import '../base.scss';
-$primary-colour: #df691a;
+﻿$primary-colour: #df691a;
 $primary-colour-outline: #ff761b;
 $bg-colour: #333333;
 $bg-colour-disabled: #252424;

--- a/src/Ombi/ClientApp/styles/base.scss
+++ b/src/Ombi/ClientApp/styles/base.scss
@@ -884,6 +884,10 @@ textarea {
     border: 1px solid $form-color-lighter;
 }
 
+.ui-treetable tfoot td, .ui-treetable th {
+    text-align: left;
+}
+
 .ui-treetable tbody td {
     white-space: inherit;
     overflow: visible;


### PR DESCRIPTION
So, we were apparently importing base.scss twice. One in main.ts and once in plex.scss. I knew I was seeing the same styles twice!

Also @gold007eye this aligns the table headers to the left.