### PR TITLE
Added the ability to refresh out backend metadata

### DIFF
--- a/src/Ombi.Api/HttpRequestExtnesions.cs
+++ b/src/Ombi.Api/HttpRequestExtnesions.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Ombi.Api
+{
+    public static class HttpRequestExtnesions
+    {
+        public static async Task<HttpRequestMessage> Clone(this HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Content = await request.Content.Clone(),
+                Version = request.Version
+            };
+            foreach (KeyValuePair<string, object> prop in request.Properties)
+            {
+                clone.Properties.Add(prop);
+            }
+            foreach (KeyValuePair<string, IEnumerable<string>> header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
+        }
+
+        public static async Task<HttpContent> Clone(this HttpContent content)
+        {
+            if (content == null) return null;
+
+            var ms = new MemoryStream();
+            await content.CopyToAsync(ms);
+            ms.Position = 0;
+
+            var clone = new StreamContent(ms);
+            foreach (KeyValuePair<string, IEnumerable<string>> header in content.Headers)
+            {
+                clone.Headers.Add(header.Key, header.Value);
+            }
+            return clone;
+        }
+    }
+}

--- a/src/Ombi.Api/Ombi.Api.csproj
+++ b/src/Ombi.Api/Ombi.Api.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Polly" Version="5.8.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/Ombi.Api/Request.cs
+++ b/src/Ombi.Api/Request.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Text;
 
@@ -24,6 +25,9 @@ namespace Ombi.Api
         public string Endpoint { get; }
         public string BaseUrl { get; }
         public HttpMethod HttpMethod { get; }
+
+        public bool Retry { get; set; }
+        public List<HttpStatusCode> StatusCodeToRetry { get; set; } = new List<HttpStatusCode>();
 
         public Action<string> OnBeforeDeserialization { get; set; }
 

--- a/src/Ombi.DependencyInjection/IocExtensions.cs
+++ b/src/Ombi.DependencyInjection/IocExtensions.cs
@@ -172,6 +172,7 @@ namespace Ombi.DependencyInjection
             services.AddTransient<ICouchPotatoSync, CouchPotatoSync>();
             services.AddTransient<IProcessProvider, ProcessProvider>();
             services.AddTransient<ISickRageSync, SickRageSync>();
+            services.AddTransient<IRefreshMetadata, RefreshMetadata>();
         }
     }
 }

--- a/src/Ombi.Schedule/JobSetup.cs
+++ b/src/Ombi.Schedule/JobSetup.cs
@@ -54,8 +54,7 @@ namespace Ombi.Schedule
             RecurringJob.AddOrUpdate(() => _plexContentSync.CacheContent(), JobSettingsHelper.PlexContent(s));
             RecurringJob.AddOrUpdate(() => _cpCache.Start(), JobSettingsHelper.CouchPotato(s));
             RecurringJob.AddOrUpdate(() => _srSync.Start(), JobSettingsHelper.SickRageSync(s));
-            //RecurringJob.AddOrUpdate(() => _refreshMetadata.Start(), JobSettingsHelper.RefreshMetadata(s));
-            BackgroundJob.Enqueue(() => _refreshMetadata.Start());
+            RecurringJob.AddOrUpdate(() => _refreshMetadata.Start(), JobSettingsHelper.RefreshMetadata(s));
 
             RecurringJob.AddOrUpdate(() => _updater.Update(null), JobSettingsHelper.Updater(s));
 

--- a/src/Ombi.Schedule/JobSetup.cs
+++ b/src/Ombi.Schedule/JobSetup.cs
@@ -17,46 +17,50 @@ namespace Ombi.Schedule
         public JobSetup(IPlexContentSync plexContentSync, IRadarrSync radarrSync,
             IOmbiAutomaticUpdater updater, IEmbyContentSync embySync, IPlexUserImporter userImporter,
             IEmbyUserImporter embyUserImporter, ISonarrSync cache, ICouchPotatoSync cpCache,
-            ISettingsService<JobSettings> jobsettings, ISickRageSync srSync)
+            ISettingsService<JobSettings> jobsettings, ISickRageSync srSync, IRefreshMetadata refresh)
         {
-            PlexContentSync = plexContentSync;
-            RadarrSync = radarrSync;
-            Updater = updater;
-            EmbyContentSync = embySync;
-            PlexUserImporter = userImporter;
-            EmbyUserImporter = embyUserImporter;
-            SonarrSync = cache;
-            CpCache = cpCache;
-            JobSettings = jobsettings;
-            SrSync = srSync;
+            _plexContentSync = plexContentSync;
+            _radarrSync = radarrSync;
+            _updater = updater;
+            _embyContentSync = embySync;
+            _plexUserImporter = userImporter;
+            _embyUserImporter = embyUserImporter;
+            _sonarrSync = cache;
+            _cpCache = cpCache;
+            _jobSettings = jobsettings;
+            _srSync = srSync;
+            _refreshMetadata = refresh;
         }
 
-        private IPlexContentSync PlexContentSync { get; }
-        private IRadarrSync RadarrSync { get; }
-        private IOmbiAutomaticUpdater Updater { get; }
-        private IPlexUserImporter PlexUserImporter { get; }
-        private IEmbyContentSync EmbyContentSync { get; }
-        private IEmbyUserImporter EmbyUserImporter { get; }
-        private ISonarrSync SonarrSync { get; }
-        private ICouchPotatoSync CpCache { get; }
-        private ISickRageSync SrSync { get; }
-        private ISettingsService<JobSettings> JobSettings { get; set; }
+        private readonly IPlexContentSync _plexContentSync;
+        private readonly IRadarrSync _radarrSync;
+        private readonly IOmbiAutomaticUpdater _updater;
+        private readonly IPlexUserImporter _plexUserImporter;
+        private readonly IEmbyContentSync _embyContentSync;
+        private readonly IEmbyUserImporter _embyUserImporter;
+        private readonly ISonarrSync _sonarrSync;
+        private readonly ICouchPotatoSync _cpCache;
+        private readonly ISickRageSync _srSync;
+        private readonly ISettingsService<JobSettings> _jobSettings;
+        private readonly IRefreshMetadata _refreshMetadata;
 
         public void Setup()
         {
-            var s = JobSettings.GetSettings();
+            var s = _jobSettings.GetSettings();
 
-            RecurringJob.AddOrUpdate(() => EmbyContentSync.Start(), JobSettingsHelper.EmbyContent(s));
-            RecurringJob.AddOrUpdate(() => SonarrSync.Start(), JobSettingsHelper.Sonarr(s));
-            RecurringJob.AddOrUpdate(() => RadarrSync.CacheContent(), JobSettingsHelper.Radarr(s));
-            RecurringJob.AddOrUpdate(() => PlexContentSync.CacheContent(), JobSettingsHelper.PlexContent(s));
-            RecurringJob.AddOrUpdate(() => CpCache.Start(), JobSettingsHelper.CouchPotato(s));
-            RecurringJob.AddOrUpdate(() => SrSync.Start(), JobSettingsHelper.SickRageSync(s));
+            RecurringJob.AddOrUpdate(() => _embyContentSync.Start(), JobSettingsHelper.EmbyContent(s));
+            RecurringJob.AddOrUpdate(() => _sonarrSync.Start(), JobSettingsHelper.Sonarr(s));
+            RecurringJob.AddOrUpdate(() => _radarrSync.CacheContent(), JobSettingsHelper.Radarr(s));
+            RecurringJob.AddOrUpdate(() => _plexContentSync.CacheContent(), JobSettingsHelper.PlexContent(s));
+            RecurringJob.AddOrUpdate(() => _cpCache.Start(), JobSettingsHelper.CouchPotato(s));
+            RecurringJob.AddOrUpdate(() => _srSync.Start(), JobSettingsHelper.SickRageSync(s));
+            //RecurringJob.AddOrUpdate(() => _refreshMetadata.Start(), JobSettingsHelper.RefreshMetadata(s));
+            BackgroundJob.Enqueue(() => _refreshMetadata.Start());
 
-            RecurringJob.AddOrUpdate(() => Updater.Update(null), JobSettingsHelper.Updater(s));
+            RecurringJob.AddOrUpdate(() => _updater.Update(null), JobSettingsHelper.Updater(s));
 
-            RecurringJob.AddOrUpdate(() => EmbyUserImporter.Start(), JobSettingsHelper.UserImporter(s));
-            RecurringJob.AddOrUpdate(() => PlexUserImporter.Start(), JobSettingsHelper.UserImporter(s));
+            RecurringJob.AddOrUpdate(() => _embyUserImporter.Start(), JobSettingsHelper.UserImporter(s));
+            RecurringJob.AddOrUpdate(() => _plexUserImporter.Start(), JobSettingsHelper.UserImporter(s));
         }
     }
 }

--- a/src/Ombi.Schedule/Jobs/Ombi/IRefreshMetadata.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/IRefreshMetadata.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Ombi.Schedule.Jobs.Ombi
+{
+    public interface IRefreshMetadata : IBaseJob
+    {
+        Task Start();
+    }
+}

--- a/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
@@ -211,19 +211,9 @@ namespace Ombi.Schedule.Jobs.Ombi
                     return externalResult.imdb_id;
                 }
             }
-        }
-        private async Task<string> GetImdbWithTheMovieDbId(string movieDbId, string title, string type)
-        {
-            _log.LogInformation("The {0} {1} has TheMovieDb but not ImdbId, searching for ImdbId", type, title);
-            if (int.TryParse(movieDbId, out var id))
-            {
-                var result = await _movieApi.GetMovieInformation(id);
-
-                _log.LogInformation("Setting {0} {1} Imdbid to {2}", type, title, result.ImdbId);
-                return result.ImdbId;
-            }
             return string.Empty;
         }
+        
 
         private async Task StartEmby()
         {

--- a/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
@@ -52,13 +52,8 @@ namespace Ombi.Schedule.Jobs.Ombi
 
                 if (!hasImdb && hasTheMovieDb)
                 {
-                    _log.LogInformation("The movie {0} has TheMovieDb but not ImdbId, searching for ImdbId", movie.Title);
-                    if (int.TryParse(movie.TheMovieDbId, out var id))
-                    {
-                        var result = await _movieApi.GetMovieInformation(id);
-                        movie.ImdbId = result.ImdbId;
-                        _log.LogInformation("Setting movie {0} Imdbid to {1}", movie.Title, movie.ImdbId);
-                    }
+                    var imdbId = await GetImdbWithTheMovieDbId("movie", movie.Title, movie.TheMovieDbId);
+                    movie.ImdbId = imdbId;
                 }
                 if (!hasTheMovieDb && hasImdb)
                 {
@@ -167,6 +162,19 @@ namespace Ombi.Schedule.Jobs.Ombi
                 }
             }
 
+        }
+
+        private async Task<string> GetImdbWithTheMovieDbId(string movieDbId, string title, string type)
+        {
+            _log.LogInformation("The {0} {1} has TheMovieDb but not ImdbId, searching for ImdbId", type, title);
+            if (int.TryParse(movieDbId, out var id))
+            {
+                var result = await _movieApi.GetMovieInformation(id);
+              
+                _log.LogInformation("Setting {0} {1} Imdbid to {2}", type, title, result.ImdbId);
+                return result.ImdbId;
+            }
+            return string.Empty;
         }
 
         private async Task StartEmby()

--- a/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/RefreshMetadata.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Ombi.Api.TheMovieDb;
+using Ombi.Api.TheMovieDb.Models;
+using Ombi.Core.Settings;
+using Ombi.Core.Settings.Models.External;
+using Ombi.Helpers;
+using Ombi.Store.Entities;
+using Ombi.Store.Repository;
+using Ombi.Store.Repository.Requests;
+
+namespace Ombi.Schedule.Jobs.Ombi
+{
+    public class RefreshMetadata : IBaseJob
+    {
+        public RefreshMetadata(IPlexContentRepository plexRepo, IEmbyContentRepository embyRepo,
+            ILogger<RefreshMetadata> log,
+            IMovieDbApi movieApi)
+        {
+            _plexRepo = plexRepo;
+            _embyRepo = embyRepo;
+            _log = log;
+            _movieApi = movieApi;
+        }
+
+        private readonly IPlexContentRepository _plexRepo;
+        private readonly IEmbyContentRepository _embyRepo;
+        private readonly ILogger _log;
+        private readonly IMovieDbApi _movieApi;
+
+        public async Task Start()
+        {
+            _log.LogInformation("Starting the Metadata refresh");
+            await StartPlex();
+            await StartEmby();
+        }
+
+        private async Task StartPlex()
+        {
+            var allMovies = _plexRepo.GetAll().Where(x => x.Type == PlexMediaTypeEntity.Movie);
+
+            foreach (var movie in allMovies)
+            {
+                var hasImdb = movie.ImdbId.HasValue();
+                var hasTheMovieDb = movie.TheMovieDbId.HasValue();
+                // Movies don't really use TheTvDb
+
+                if (!hasImdb && hasTheMovieDb)
+                {
+                    if (int.TryParse(movie.TheMovieDbId, out var id))
+                    {
+                        var result = await _movieApi.GetMovieInformation(id);
+                        movie.ImdbId = result.ImdbId;
+                    }
+                }
+                if (!hasTheMovieDb && hasImdb)
+                {
+                    var result = await _movieApi.Find(movie.ImdbId, ExternalSource.imdb_id);
+                    movie.TheMovieDbId = result.movie_results?[0]?.id.ToString() ?? string.Empty;
+                }
+            }
+
+            await _plexRepo.UpdateRange(allMovies);
+            
+            // Now Tv
+
+            var allTv = _plexRepo.GetAll().Where(x => x.Type == PlexMediaTypeEntity.Show);
+            foreach (var show in allTv)
+            {
+                var hasImdb = show.ImdbId.HasValue();
+                var hasTheMovieDb = show.TheMovieDbId.HasValue();
+                var hasTvDbId = show.TvDbId.HasValue();
+
+                if (!hasTheMovieDb)
+                {
+                    FindResult result = null;
+                    var hasResult = false;
+                    if (hasTvDbId)
+                    {
+                        result = await _movieApi.Find(show.TvDbId, ExternalSource.tvdb_id);
+                        hasResult = result != null;
+                    }
+                    if (hasImdb && !hasResult)
+                    {
+                        result = await _movieApi.Find(show.ImdbId, ExternalSource.imdb_id);
+                        hasResult = result != null;
+                    }
+                    if (hasResult)
+                    {
+                        show.TheMovieDbId = result.tv_results?[0]?.id.ToString() ?? string.Empty;
+                    }
+                }
+
+                if (!hasImdb)
+                {
+                    if (hasTheMovieDb)
+                    {
+                        // We can check here for the ID
+                    }
+                }
+            }
+
+        }
+
+        private async Task StartEmby()
+        {
+
+        }
+
+
+        private bool _disposed;
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+                return;
+
+            if (disposing)
+            {
+                _plexRepo?.Dispose();
+                _embyRepo?.Dispose();
+            }
+            _disposed = true;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Ombi.Schedule/Ombi.Schedule.csproj
+++ b/src/Ombi.Schedule/Ombi.Schedule.csproj
@@ -32,6 +32,7 @@
     <ProjectReference Include="..\Ombi.Api.Service\Ombi.Api.Service.csproj" />
     <ProjectReference Include="..\Ombi.Api.SickRage\Ombi.Api.SickRage.csproj" />
     <ProjectReference Include="..\Ombi.Api.Sonarr\Ombi.Api.Sonarr.csproj" />
+    <ProjectReference Include="..\Ombi.Api.TvMaze\Ombi.Api.TvMaze.csproj" />
     <ProjectReference Include="..\Ombi.Notifications\Ombi.Notifications.csproj" />
     <ProjectReference Include="..\Ombi.Settings\Ombi.Settings.csproj" />
     <ProjectReference Include="..\Ombi.TheMovieDbApi\Ombi.Api.TheMovieDb.csproj" />

--- a/src/Ombi.Schedule/Ombi.Schedule.csproj
+++ b/src/Ombi.Schedule/Ombi.Schedule.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\Ombi.Api.Sonarr\Ombi.Api.Sonarr.csproj" />
     <ProjectReference Include="..\Ombi.Notifications\Ombi.Notifications.csproj" />
     <ProjectReference Include="..\Ombi.Settings\Ombi.Settings.csproj" />
+    <ProjectReference Include="..\Ombi.TheMovieDbApi\Ombi.Api.TheMovieDb.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Ombi.Settings/Settings/Models/JobSettings.cs
+++ b/src/Ombi.Settings/Settings/Models/JobSettings.cs
@@ -10,5 +10,6 @@
         public string AutomaticUpdater { get; set; }
         public string UserImporter { get; set; }
         public string SickRageSync { get; set; }
+        public string RefreshMetadata { get; set; }
     }
 }

--- a/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
+++ b/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
@@ -39,6 +39,10 @@ namespace Ombi.Settings.Settings.Models
         {
             return Get(s.SickRageSync, Cron.Hourly(35));
         }
+        public static string RefreshMetadata(JobSettings s)
+        {
+            return Get(s.RefreshMetadata, Cron.Hourly(40));
+        }
 
 
         private static string Get(string settings, string defaultCron)

--- a/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
+++ b/src/Ombi.Settings/Settings/Models/JobSettingsHelper.cs
@@ -41,7 +41,7 @@ namespace Ombi.Settings.Settings.Models
         }
         public static string RefreshMetadata(JobSettings s)
         {
-            return Get(s.RefreshMetadata, Cron.Hourly(40));
+            return Get(s.RefreshMetadata, Cron.Daily(3));
         }
 
 

--- a/src/Ombi.Store/Repository/IPlexContentRepository.cs
+++ b/src/Ombi.Store/Repository/IPlexContentRepository.cs
@@ -23,5 +23,6 @@ namespace Ombi.Store.Repository
         void DeleteWithoutSave(PlexServerContent content);
         void DeleteWithoutSave(PlexEpisode content);
         Task UpdateRange(IEnumerable<PlexServerContent> existingContent);
+        void UpdateWithoutSave(PlexServerContent existingContent);
     }
 }

--- a/src/Ombi.Store/Repository/IPlexContentRepository.cs
+++ b/src/Ombi.Store/Repository/IPlexContentRepository.cs
@@ -22,5 +22,6 @@ namespace Ombi.Store.Repository
         Task DeleteEpisode(PlexEpisode content);
         void DeleteWithoutSave(PlexServerContent content);
         void DeleteWithoutSave(PlexEpisode content);
+        Task UpdateRange(IEnumerable<PlexServerContent> existingContent);
     }
 }

--- a/src/Ombi.Store/Repository/IRepository.cs
+++ b/src/Ombi.Store/Repository/IRepository.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Query;
 using Ombi.Store.Entities;
 
@@ -24,5 +25,6 @@ namespace Ombi.Store.Repository
             where TEntity : class;
 
         Task ExecuteSql(string sql);
+        DbSet<T> _db;
     }
 }

--- a/src/Ombi.Store/Repository/IRepository.cs
+++ b/src/Ombi.Store/Repository/IRepository.cs
@@ -25,6 +25,6 @@ namespace Ombi.Store.Repository
             where TEntity : class;
 
         Task ExecuteSql(string sql);
-        DbSet<T> _db;
+        DbSet<T> _db { get; }
     }
 }

--- a/src/Ombi.Store/Repository/PlexContentRepository.cs
+++ b/src/Ombi.Store/Repository/PlexContentRepository.cs
@@ -98,6 +98,12 @@ namespace Ombi.Store.Repository
             await Db.SaveChangesAsync();
         }
 
+        public async Task UpdateRange(IEnumerable<PlexServerContent> existingContent)
+        {
+            Db.PlexServerContent.UpdateRange(existingContent);
+            await Db.SaveChangesAsync();
+        }
+
         public IQueryable<PlexEpisode> GetAllEpisodes()
         {
             return Db.PlexEpisode.Include(x => x.Series).AsQueryable();

--- a/src/Ombi.Store/Repository/PlexContentRepository.cs
+++ b/src/Ombi.Store/Repository/PlexContentRepository.cs
@@ -97,6 +97,10 @@ namespace Ombi.Store.Repository
             Db.PlexServerContent.Update(existingContent);
             await Db.SaveChangesAsync();
         }
+        public void UpdateWithoutSave(PlexServerContent existingContent)
+        {
+            Db.PlexServerContent.Update(existingContent);
+        }
 
         public async Task UpdateRange(IEnumerable<PlexServerContent> existingContent)
         {

--- a/src/Ombi.Store/Repository/Repository.cs
+++ b/src/Ombi.Store/Repository/Repository.cs
@@ -17,7 +17,7 @@ namespace Ombi.Store.Repository
             _ctx = ctx;
             _db = _ctx.Set<T>();
         }
-        private readonly DbSet<T> _db;
+        public readonly DbSet<T> _db;
         private readonly IOmbiContext _ctx;
 
         public async Task<T> Find(object key)

--- a/src/Ombi.Store/Repository/Repository.cs
+++ b/src/Ombi.Store/Repository/Repository.cs
@@ -17,7 +17,7 @@ namespace Ombi.Store.Repository
             _ctx = ctx;
             _db = _ctx.Set<T>();
         }
-        public readonly DbSet<T> _db;
+        public DbSet<T> _db { get; }
         private readonly IOmbiContext _ctx;
 
         public async Task<T> Find(object key)

--- a/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
@@ -16,5 +16,6 @@ namespace Ombi.Api.TheMovieDb
         Task<List<MovieSearchResult>> Upcoming();
         Task<List<MovieSearchResult>> SimilarMovies(int movieId);
         Task<FindResult> Find(string externalId, ExternalSource source);
+        Task<TvExternals> GetTvExternals(int theMovieDbId);
     }
 }

--- a/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/IMovieDbApi.cs
@@ -15,5 +15,6 @@ namespace Ombi.Api.TheMovieDb
         Task<List<MovieSearchResult>> TopRated();
         Task<List<MovieSearchResult>> Upcoming();
         Task<List<MovieSearchResult>> SimilarMovies(int movieId);
+        Task<FindResult> Find(string externalId, ExternalSource source);
     }
 }

--- a/src/Ombi.TheMovieDbApi/Models/FindResult.cs
+++ b/src/Ombi.TheMovieDbApi/Models/FindResult.cs
@@ -1,0 +1,52 @@
+﻿namespace Ombi.Api.TheMovieDb.Models
+{
+    public class FindResult
+    {
+        public Movie_Results[] movie_results { get; set; }
+        public object[] person_results { get; set; }
+        public TvResults[] tv_results { get; set; }
+        public object[] tv_episode_results { get; set; }
+        public object[] tv_season_results { get; set; }
+    }
+
+    public class Movie_Results
+    {
+        public bool adult { get; set; }
+        public string backdrop_path { get; set; }
+        public int[] genre_ids { get; set; }
+        public int id { get; set; }
+        public string original_language { get; set; }
+        public string original_title { get; set; }
+        public string overview { get; set; }
+        public string poster_path { get; set; }
+        public string release_date { get; set; }
+        public string title { get; set; }
+        public bool video { get; set; }
+        public float vote_average { get; set; }
+        public int vote_count { get; set; }
+    }
+
+
+    public class TvResults
+    {
+        public string original_name { get; set; }
+        public int id { get; set; }
+        public string name { get; set; }
+        public int vote_count { get; set; }
+        public float vote_average { get; set; }
+        public string first_air_date { get; set; }
+        public string poster_path { get; set; }
+        public int[] genre_ids { get; set; }
+        public string original_language { get; set; }
+        public string backdrop_path { get; set; }
+        public string overview { get; set; }
+        public string[] origin_country { get; set; }
+    }
+
+
+    public enum ExternalSource
+    {
+        imdb_id,
+        tvdb_id
+    }
+}

--- a/src/Ombi.TheMovieDbApi/Models/TvExternals.cs
+++ b/src/Ombi.TheMovieDbApi/Models/TvExternals.cs
@@ -1,0 +1,16 @@
+﻿namespace Ombi.Api.TheMovieDb.Models
+{
+    public class TvExternals
+    {
+        public string imdb_id { get; set; }
+        public string freebase_mid { get; set; }
+        public string freebase_id { get; set; }
+        public int tvdb_id { get; set; }
+        public int tvrage_id { get; set; }
+        public string facebook_id { get; set; }
+        public object instagram_id { get; set; }
+        public object twitter_id { get; set; }
+        public int id { get; set; }
+    }
+
+}

--- a/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
@@ -30,6 +30,16 @@ namespace Ombi.Api.TheMovieDb
             return Mapper.Map<MovieResponseDto>(result);
         }
 
+        public async Task<FindResult> Find(string externalId, ExternalSource source)
+        {
+            var request = new Request($"find/{externalId}", BaseUri, HttpMethod.Get);
+            request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+
+            request.AddQueryString("external_source", source.ToString());
+
+            return await Api.Request<FindResult>(request);
+        }
+
         public async Task<List<MovieSearchResult>> SimilarMovies(int movieId)
         {
             var request = new Request($"movie/{movieId}/similar", BaseUri, HttpMethod.Get);

--- a/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using AutoMapper;
@@ -25,6 +26,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/{movieId}", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
 
             var result = await Api.Request<MovieResponse>(request);
             return Mapper.Map<MovieResponseDto>(result);
@@ -34,6 +36,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"find/{externalId}", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
 
             request.AddQueryString("external_source", source.ToString());
 
@@ -44,6 +47,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"/tv/{theMovieDbId}/external_ids", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
 
             return await Api.Request<TvExternals>(request);
         }
@@ -52,6 +56,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/{movieId}/similar", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
 
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
@@ -62,6 +67,7 @@ namespace Ombi.Api.TheMovieDb
             var request = new Request($"movie/{movieId}", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
             request.FullUri = request.FullUri.AddQueryParameter("append_to_response", "videos,release_dates");
+            AddRetry(request);
             var result = await Api.Request<MovieResponse>(request);
             return Mapper.Map<MovieResponseDto>(result);
         }
@@ -71,6 +77,7 @@ namespace Ombi.Api.TheMovieDb
             var request = new Request($"search/movie", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
             request.FullUri = request.FullUri.AddQueryParameter("query", searchTerm);
+            AddRetry(request);
 
             var result =  await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
@@ -80,6 +87,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/popular", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
         }
@@ -88,6 +96,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/top_rated", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
         }
@@ -96,6 +105,7 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/upcoming", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
         }
@@ -104,9 +114,14 @@ namespace Ombi.Api.TheMovieDb
         {
             var request = new Request($"movie/now_playing", BaseUri, HttpMethod.Get);
             request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
+            AddRetry(request);
             var result = await Api.Request<TheMovieDbContainer<SearchResult>>(request);
             return Mapper.Map<List<MovieSearchResult>>(result.results);
         }
-
+        private static void AddRetry(Request request)
+        {
+            request.Retry = true;
+            request.StatusCodeToRetry.Add((HttpStatusCode)429);
+        }
     }
 }

--- a/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
+++ b/src/Ombi.TheMovieDbApi/TheMovieDbApi.cs
@@ -39,7 +39,15 @@ namespace Ombi.Api.TheMovieDb
 
             return await Api.Request<FindResult>(request);
         }
+        
+        public async Task<TvExternals> GetTvExternals(int theMovieDbId)
+        {
+            var request = new Request($"/tv/{theMovieDbId}/external_ids", BaseUri, HttpMethod.Get);
+            request.FullUri = request.FullUri.AddQueryParameter("api_key", ApiToken);
 
+            return await Api.Request<TvExternals>(request);
+        }
+        
         public async Task<List<MovieSearchResult>> SimilarMovies(int movieId)
         {
             var request = new Request($"movie/{movieId}/similar", BaseUri, HttpMethod.Get);

--- a/src/Ombi/ClientApp/app/interfaces/ISettings.ts
+++ b/src/Ombi/ClientApp/app/interfaces/ISettings.ts
@@ -123,6 +123,7 @@ export interface IJobSettings {
   automaticUpdater: string;
   userImporter: string;
   sickRageSync: string;
+  refreshMetadata: string;
 }
 
 export interface IIssueSettings extends ISettings {
@@ -190,4 +191,19 @@ export interface IDogNzbSettings extends ISettings {
 
 export interface IIssueCategory extends ISettings {
   value: string;
+}
+
+export interface ICronTestModel {
+  success: boolean;
+  message: string;
+  schedule: Date[];
+}
+
+export interface ICronViewModelBody {
+  expression: string;
+}
+
+export interface IJobSettingsViewModel {
+  result: boolean;
+  message: string;
 }

--- a/src/Ombi/ClientApp/app/services/settings.service.ts
+++ b/src/Ombi/ClientApp/app/services/settings.service.ts
@@ -7,6 +7,8 @@ import {
     IAbout,
     IAuthenticationSettings,
     ICouchPotatoSettings,
+    ICronTestModel,
+    ICronViewModelBody,
     ICustomizationSettings,
     IDiscordNotifcationSettings,
     IDogNzbSettings,
@@ -14,6 +16,7 @@ import {
     IEmbySettings,
     IIssueSettings,
     IJobSettings,
+    IJobSettingsViewModel,
     ILandingPageSettings,
     IMattermostNotifcationSettings,
     IMobileNotifcationSettings,
@@ -231,10 +234,15 @@ export class SettingsService extends ServiceHelpers {
         return this.http.get<IJobSettings>(`${this.url}/jobs`, {headers: this.headers});
     }
 
-    public saveJobSettings(settings: IJobSettings): Observable<boolean> {
+    public saveJobSettings(settings: IJobSettings): Observable<IJobSettingsViewModel> {
         return this.http
-            .post<boolean>(`${this.url}/jobs`, JSON.stringify(settings), {headers: this.headers});
-    }   
+            .post<IJobSettingsViewModel>(`${this.url}/jobs`, JSON.stringify(settings), {headers: this.headers});
+    } 
+    
+    public testCron(body: ICronViewModelBody): Observable<ICronTestModel> {
+        return this.http
+            .post<ICronTestModel>(`${this.url}/testcron`, JSON.stringify(body), {headers: this.headers});
+    }
     
     public getSickRageSettings(): Observable<ISickRageSettings> {
         return this.http.get<ISickRageSettings>(`${this.url}/sickrage`, {headers: this.headers});

--- a/src/Ombi/ClientApp/app/settings/jobs/jobs.component.html
+++ b/src/Ombi/ClientApp/app/settings/jobs/jobs.component.html
@@ -12,34 +12,34 @@
                     <label for="sonarrSync" class="control-label">Sonarr Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('sonarrSync').hasError('required')}" id="sonarrSync" name="sonarrSync" formControlName="sonarrSync">
                         <small *ngIf="form.get('sonarrSync').hasError('required')" class="error-text">The Sonarr Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sonarrSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sonarrSync')?.value)">Test</button>
                 </div>
                 <div class="form-group">
                     <label for="sickRageSync" class="control-label">SickRage Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('sonarrSync').hasError('required')}" id="sickRageSync" name="sickRageSync" formControlName="sickRageSync">
                         <small *ngIf="form.get('sickRageSync').hasError('required')" class="error-text">The SickRage Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sickRageSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sickRageSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="radarrSync" class="control-label">Radarr Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('radarrSync').hasError('required')}" id="radarrSync" name="radarrSync" formControlName="radarrSync">
                         <small *ngIf="form.get('radarrSync').hasError('required')" class="error-text">The Radarr Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('radarrSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('radarrSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="couchPotatoSync" class="control-label">CouchPotato Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('radarrSync').hasError('required')}" id="couchPotatoSync" name="couchPotatoSync" formControlName="couchPotatoSync">
                         <small *ngIf="form.get('couchPotatoSync').hasError('required')" class="error-text">The CouchPotato Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('couchPotatoSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('couchPotatoSync')?.value)">Test</button>
                 </div>
                 
                 <div class="form-group">
                     <label for="automaticUpdater" class="control-label">Automatic Update</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('automaticUpdater').hasError('required')}" id="automaticUpdater" name="automaticUpdater" formControlName="automaticUpdater">
                         <small *ngIf="form.get('automaticUpdater').hasError('required')" class="error-text">The Automatic Update is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('automaticUpdater')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('automaticUpdater')?.value)">Test</button>
                 </div>
 
 
@@ -55,28 +55,28 @@
                     <label for="plexContentSync" class="control-label">Plex Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('plexContentSync').hasError('required')}" id="plexContentSync" name="plexContentSync" formControlName="plexContentSync">
                         <small *ngIf="form.get('plexContentSync').hasError('required')" class="error-text">The Plex Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('plexContentSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('plexContentSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="embyContentSync" class="control-label">Emby Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('embyContentSync').hasError('required')}" id="embyContentSync" name="embyContentSync" formControlName="embyContentSync">
                         <small *ngIf="form.get('embyContentSync').hasError('required')" class="error-text">The Emby Sync is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('embyContentSync')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('embyContentSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="userImporter" class="control-label">User Importer</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('userImporter').hasError('required')}" id="userImporter" name="userImporter" formControlName="userImporter">
                         <small *ngIf="form.get('userImporter').hasError('required')" class="error-text">The User Importer is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('userImporter')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('userImporter')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="userImporter" class="control-label">Refresh Metadata</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('refreshMetadata').hasError('required')}" id="refreshMetadata" name="refreshMetadata" formControlName="refreshMetadata">
                         <small *ngIf="form.get('refreshMetadata').hasError('required')" class="error-text">The Refresh Metadata is required</small>
-                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('refreshMetadata')?.value)">Test</button>
+                        <button type="button" class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('refreshMetadata')?.value)">Test</button>
                 </div>
 
             </div>
@@ -85,7 +85,7 @@
 </div>
 
 <p-dialog header="CRON Schedule" [(visible)]="displayTest">
-    <ul>
-        <li *ngFor="let item of testModel.schedule">{{item}}</li>
-    </ul>>
+    <ul *ngIf="testModel">
+        <li *ngFor="let item of testModel.schedule">{{item | date:'short'}}</li>
+    </ul>
 </p-dialog>

--- a/src/Ombi/ClientApp/app/settings/jobs/jobs.component.html
+++ b/src/Ombi/ClientApp/app/settings/jobs/jobs.component.html
@@ -12,29 +12,34 @@
                     <label for="sonarrSync" class="control-label">Sonarr Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('sonarrSync').hasError('required')}" id="sonarrSync" name="sonarrSync" formControlName="sonarrSync">
                         <small *ngIf="form.get('sonarrSync').hasError('required')" class="error-text">The Sonarr Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sonarrSync')?.value)">Test</button>
                 </div>
                 <div class="form-group">
                     <label for="sickRageSync" class="control-label">SickRage Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('sonarrSync').hasError('required')}" id="sickRageSync" name="sickRageSync" formControlName="sickRageSync">
                         <small *ngIf="form.get('sickRageSync').hasError('required')" class="error-text">The SickRage Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('sickRageSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="radarrSync" class="control-label">Radarr Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('radarrSync').hasError('required')}" id="radarrSync" name="radarrSync" formControlName="radarrSync">
                         <small *ngIf="form.get('radarrSync').hasError('required')" class="error-text">The Radarr Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('radarrSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="couchPotatoSync" class="control-label">CouchPotato Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('radarrSync').hasError('required')}" id="couchPotatoSync" name="couchPotatoSync" formControlName="couchPotatoSync">
                         <small *ngIf="form.get('couchPotatoSync').hasError('required')" class="error-text">The CouchPotato Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('couchPotatoSync')?.value)">Test</button>
                 </div>
                 
                 <div class="form-group">
                     <label for="automaticUpdater" class="control-label">Automatic Update</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('automaticUpdater').hasError('required')}" id="automaticUpdater" name="automaticUpdater" formControlName="automaticUpdater">
                         <small *ngIf="form.get('automaticUpdater').hasError('required')" class="error-text">The Automatic Update is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('automaticUpdater')?.value)">Test</button>
                 </div>
 
 
@@ -50,21 +55,37 @@
                     <label for="plexContentSync" class="control-label">Plex Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('plexContentSync').hasError('required')}" id="plexContentSync" name="plexContentSync" formControlName="plexContentSync">
                         <small *ngIf="form.get('plexContentSync').hasError('required')" class="error-text">The Plex Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('plexContentSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="embyContentSync" class="control-label">Emby Sync</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('embyContentSync').hasError('required')}" id="embyContentSync" name="embyContentSync" formControlName="embyContentSync">
                         <small *ngIf="form.get('embyContentSync').hasError('required')" class="error-text">The Emby Sync is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('embyContentSync')?.value)">Test</button>
                 </div>
 
                 <div class="form-group">
                     <label for="userImporter" class="control-label">User Importer</label>              
                         <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('userImporter').hasError('required')}" id="userImporter" name="userImporter" formControlName="userImporter">
                         <small *ngIf="form.get('userImporter').hasError('required')" class="error-text">The User Importer is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('userImporter')?.value)">Test</button>
+                </div>
+
+                <div class="form-group">
+                    <label for="userImporter" class="control-label">Refresh Metadata</label>              
+                        <input type="text" class="form-control form-control-custom" [ngClass]="{'form-error': form.get('refreshMetadata').hasError('required')}" id="refreshMetadata" name="refreshMetadata" formControlName="refreshMetadata">
+                        <small *ngIf="form.get('refreshMetadata').hasError('required')" class="error-text">The Refresh Metadata is required</small>
+                        <button class="btn btn-sm btn-primary-outline" (click)="testCron(form.get('refreshMetadata')?.value)">Test</button>
                 </div>
 
             </div>
         </form>
     </fieldset>
 </div>
+
+<p-dialog header="CRON Schedule" [(visible)]="displayTest">
+    <ul>
+        <li *ngFor="let item of testModel.schedule">{{item}}</li>
+    </ul>>
+</p-dialog>

--- a/src/Ombi/ClientApp/app/settings/jobs/jobs.component.ts
+++ b/src/Ombi/ClientApp/app/settings/jobs/jobs.component.ts
@@ -1,6 +1,10 @@
 ﻿import { Component, OnInit } from "@angular/core";
+import { ConfirmationService } from 'primeng/primeng';
+
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { NotificationService, SettingsService } from "../../services";
+
+import { ICronTestModel } from "./../../interfaces";
 
 @Component({
     templateUrl: "./jobs.component.html",
@@ -10,6 +14,8 @@ export class JobsComponent implements OnInit {
     public form: FormGroup;
     
     public profilesRunning: boolean;
+    public testModel: ICronTestModel;
+    public displayTest: boolean;
     
     constructor(private readonly settingsService: SettingsService,
                 private readonly fb: FormBuilder,
@@ -26,7 +32,19 @@ export class JobsComponent implements OnInit {
                 sonarrSync:               [x.radarrSync, Validators.required],
                 radarrSync:               [x.sonarrSync, Validators.required],
                 sickRageSync:             [x.sickRageSync, Validators.required],  
-            });
+                refreshMetadata:          [x.refreshMetadata, Validators.required],
+            });  
+        });
+    }
+
+    public testCron(expression: string) {
+        this.settingsService.testCron({ expression }).subscribe(x => {
+            if(x.success) {
+                this.testModel = x;
+                this.displayTest = true;              
+            } else {
+                this.notificationService.error(x.message);
+            }
         });
     }
     
@@ -37,10 +55,10 @@ export class JobsComponent implements OnInit {
         }
         const settings = form.value;
         this.settingsService.saveJobSettings(settings).subscribe(x => {
-            if (x) {
+            if (x.result) {
                 this.notificationService.success("Successfully saved the job settings");
             } else {
-                this.notificationService.success("There was an error when saving the job settings");
+                this.notificationService.error("There was an error when saving the job settings. " + x.message);
             }
         });
     }

--- a/src/Ombi/ClientApp/app/settings/jobs/jobs.component.ts
+++ b/src/Ombi/ClientApp/app/settings/jobs/jobs.component.ts
@@ -1,5 +1,4 @@
 ﻿import { Component, OnInit } from "@angular/core";
-import { ConfirmationService } from 'primeng/primeng';
 
 import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { NotificationService, SettingsService } from "../../services";

--- a/src/Ombi/ClientApp/app/settings/settings.module.ts
+++ b/src/Ombi/ClientApp/app/settings/settings.module.ts
@@ -88,6 +88,7 @@ const routes: Routes = [
         ClipboardModule,
         PipeModule,
         RadioButtonModule,
+        DialogModule,
     ],
     declarations: [
         SettingsMenuComponent,
@@ -118,7 +119,6 @@ const routes: Routes = [
         AuthenticationComponent,
         MobileComponent,
         MassEmailComponent,
-        DialogModule,
     ],
     exports: [
         RouterModule,

--- a/src/Ombi/ClientApp/app/settings/settings.module.ts
+++ b/src/Ombi/ClientApp/app/settings/settings.module.ts
@@ -41,7 +41,7 @@ import { WikiComponent } from "./wiki.component";
 
 import { SettingsMenuComponent } from "./settingsmenu.component";
 
-import { AutoCompleteModule, CalendarModule, InputSwitchModule, InputTextModule, MenuModule, RadioButtonModule, TooltipModule } from "primeng/primeng";
+import { AutoCompleteModule, CalendarModule, DialogModule, InputSwitchModule, InputTextModule, MenuModule, RadioButtonModule, TooltipModule } from "primeng/primeng";
 
 const routes: Routes = [
     { path: "Ombi", component: OmbiComponent, canActivate: [AuthGuard] },
@@ -118,6 +118,7 @@ const routes: Routes = [
         AuthenticationComponent,
         MobileComponent,
         MassEmailComponent,
+        DialogModule,
     ],
     exports: [
         RouterModule,

--- a/src/Ombi/Controllers/SettingsController.cs
+++ b/src/Ombi/Controllers/SettingsController.cs
@@ -493,7 +493,14 @@ namespace Ombi.Controllers
 
                 try
                 {
-                    CrontabSchedule.TryParse(expression);
+                    var r = CrontabSchedule.TryParse(expression);
+                    if (r == null)
+                    {
+                        return new JobSettingsViewModel
+                        {
+                            Message = $"{propertyInfo.Name} does not have a valid CRON Expression"
+                        };
+                    }
                 }
                 catch (Exception)
                 {
@@ -517,11 +524,13 @@ namespace Ombi.Controllers
             var model = new CronTestModel();
             try
             {
-                var baseTime = DateTime.UtcNow;
+                var time = DateTime.UtcNow;
                 var result = CrontabSchedule.TryParse(body.Expression);
                 for (int i = 0; i < 10; i++)
                 {
-                    model.Schedule.Add(result.GetNextOccurrence(baseTime));
+                    var next = result.GetNextOccurrence(time);
+                    model.Schedule.Add(next);
+                    time = next;
                 }
                 model.Success = true;
                 return model;

--- a/src/Ombi/Models/CronTestModel.cs
+++ b/src/Ombi/Models/CronTestModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Ombi.Models
+{
+    public class CronTestModel
+    {
+        public bool Success { get; set; }
+        public string Message { get; set; }
+        public List<DateTime> Schedule { get; set; } = new List<DateTime>();
+    }
+}

--- a/src/Ombi/Models/CronViewModelBody.cs
+++ b/src/Ombi/Models/CronViewModelBody.cs
@@ -1,0 +1,7 @@
+﻿namespace Ombi.Models
+{
+    public class CronViewModelBody
+    {
+        public string Expression { get; set; }
+    }
+}

--- a/src/Ombi/Models/JobSettingsViewModel.cs
+++ b/src/Ombi/Models/JobSettingsViewModel.cs
@@ -1,0 +1,8 @@
+﻿namespace Ombi.Models
+{
+    public class JobSettingsViewModel
+    {
+        public bool Result { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/src/Ombi/Ombi.csproj
+++ b/src/Ombi/Ombi.csproj
@@ -66,6 +66,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="2.0.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.0.0" />
     <PackageReference Include="MiniProfiler.AspNetCore.Mvc" Version="4.0.0-alpha6-79" />
+    <PackageReference Include="ncrontab" Version="3.3.0" />
     <PackageReference Include="Serilog" Version="2.6.0-dev-00892" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="3.2.0" />

--- a/src/Ombi/package-lock.json
+++ b/src/Ombi/package-lock.json
@@ -5140,6 +5140,7 @@
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.6.0.tgz",
       "integrity": "sha512-mt839mCsI5hzdBJLf1iRBwt610P35iUfvqLVuL7VFdanUwRBAmGtbsjdGIuzegplR95xx+fTHE0vBMuMJp1sLQ==",
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.1",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -5174,7 +5175,6 @@
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
         "is-cidr": "1.0.0",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.7.1",
         "lockfile": "1.0.3",
@@ -5248,6 +5248,24 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.1",
           "bundled": true
@@ -5646,24 +5664,6 @@
           "dependencies": {
             "cidr-regex": {
               "version": "1.0.6",
-              "bundled": true
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
               "bundled": true
             }
           }
@@ -10843,14 +10843,6 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -10859,6 +10851,14 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
We now can refresh the Plex Metadata in our database. For example if the Plex Agent for TV Shows is TheMovieDb, we will use that and populate the IMDB Id and TheTvDb Id's so we can accuratly match and search things.

Also improved the Job settings page so we can Test CRON's and we also validate them.