### PR TITLE
Use selected episodes in submitRequest

### DIFF
--- a/src/Ombi/ClientApp/app/search/seriesinformation.component.ts
+++ b/src/Ombi/ClientApp/app/search/seriesinformation.component.ts
@@ -52,7 +52,7 @@ export class SeriesInformationComponent implements OnInit {
             const seasonsViewModel = <ISeasonsViewModel>{seasonNumber: season.seasonNumber, episodes: []};
             season.episodes.forEach(ep => {
                 if(!this.series.latestSeason || !this.series.requestAll || !this.series.firstSeason) {
-                    if(ep.requested) {
+                    if(ep.selected) {
                         seasonsViewModel.episodes.push({episodeNumber: ep.episodeNumber});
                     }
                 }


### PR DESCRIPTION
Currently it's not possible to edit an already requested series, because the request params are populated with already requested episodes in addition to the selected ones. I hope this will fix it.