### PR TITLE
Add clearfix class. Closes #2486

### DIFF
--- a/src/Ombi/ClientApp/app/requests/tvrequest-children.component.html
+++ b/src/Ombi/ClientApp/app/requests/tvrequest-children.component.html
@@ -1,6 +1,6 @@
 ﻿<div *ngIf="childRequests">
     <hr />
-    <div *ngFor="let child of childRequests">
+    <div *ngFor="let child of childRequests" class="clearfix">
         <div class="col-md-12">
 
             <div class="col-md-2">


### PR DESCRIPTION
Pretty sure that Firefox's behavior is incorrect in this case. Since the floated content is the full width of the container, it *should* push the rest of the content down, like it does in chrome. ¯\_(ツ)_/¯