### PR TITLE
Fix timezone bug

### DIFF
--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -516,7 +516,7 @@ namespace Ombi.Core.Engine
                 HasLimit = true,    
                 Limit = limit,
                 Remaining = count,
-                NextRequest = oldestRequestedAt.AddDays(7),
+                NextRequest = DateTime.SpecifyKind(oldestRequestedAt.AddDays(7), DateTimeKind.Utc),
             };
         }
     }

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -652,7 +652,7 @@ namespace Ombi.Core.Engine
                 HasLimit = true,    
                 Limit = limit,
                 Remaining = count,
-                NextRequest = oldestRequestedAt.AddDays(7),
+                NextRequest = DateTime.SpecifyKind(oldestRequestedAt.AddDays(7), DateTimeKind.Utc),
             };
         }
     }

--- a/src/Ombi.Schedule.Tests/NewsletterTests.cs
+++ b/src/Ombi.Schedule.Tests/NewsletterTests.cs
@@ -18,7 +18,7 @@ namespace Ombi.Schedule.Tests
             var emailSettings = new Mock<ISettingsService<EmailNotificationSettings>>();
             var customziation = new Mock<ISettingsService<CustomizationSettings>>();
             var newsletterSettings = new Mock<ISettingsService<NewsletterSettings>>();
-            var newsletter = new NewsletterJob(null, null, null, null, null, null, customziation.Object, emailSettings.Object, null, null, newsletterSettings.Object, null);
+            var newsletter = new NewsletterJob(null, null, null, null, null, null, customziation.Object, emailSettings.Object, null, null, newsletterSettings.Object, null, null, null, null);
 
             var ep = new List<int>();
             foreach (var i in episodes)


### PR DESCRIPTION
Fixes bug which would cause the countdown to the next request to be wrong/absent.

The json being returned from the `GetRemainingRequests` action in `MovieRequestEngine`/`TvRequestEngine` didn't contain a timezone, so relied on the client to provide the timezone, causing the bug.

Also adds a bodge fix to the `NewsletterTests.cs` test. Although the test still fails, the build fails without this change, due to the wrong number of params passed to `NewsletterJob`.

**Before change**
Note that the user has no items left in their quota, however the countdown for the next item is not shown:

![image](https://user-images.githubusercontent.com/774415/44941193-9fa3ad00-ad90-11e8-9423-a0ba5b09e55c.png)

**After change**
Count down timer displays correctly:
![image](https://user-images.githubusercontent.com/774415/44941254-a979e000-ad91-11e8-91b7-e280c8d4c126.png)

