### PR TITLE
Display quota on user managment page

### DIFF
--- a/src/Ombi.Core/Engine/Interfaces/IRequestEngine.cs
+++ b/src/Ombi.Core/Engine/Interfaces/IRequestEngine.cs
@@ -23,6 +23,6 @@ namespace Ombi.Core.Engine.Interfaces
         Task<int> GetTotal();
         Task UnSubscribeRequest(int requestId, RequestType type);
         Task SubscribeToRequest(int requestId, RequestType type);
-        Task<RequestQuotaCountModel> GetRemainingRequests();
+        Task<RequestQuotaCountModel> GetRemainingRequests(OmbiUser user = null);
     }
 }

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -491,6 +491,12 @@ namespace Ombi.Core.Engine
             if (user == null)
             {
                 user = await GetUser();
+
+                // If user is still null after attempting to get the logged in user, return null.
+                if (user == null)
+                {
+                    return null;
+                }
             }
 
             int limit = user.MovieRequestLimit ?? 0;

--- a/src/Ombi.Core/Engine/MovieRequestEngine.cs
+++ b/src/Ombi.Core/Engine/MovieRequestEngine.cs
@@ -486,9 +486,13 @@ namespace Ombi.Core.Engine
             return new RequestEngineResult {Result = true, Message = $"{movieName} has been successfully added!"};
         }
 
-        public async Task<RequestQuotaCountModel> GetRemainingRequests()
+        public async Task<RequestQuotaCountModel> GetRemainingRequests(OmbiUser user)
         {
-            OmbiUser user = await GetUser();
+            if (user == null)
+            {
+                user = await GetUser();
+            }
+
             int limit = user.MovieRequestLimit ?? 0;
 
             if (limit <= 0)

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -620,6 +620,12 @@ namespace Ombi.Core.Engine
             if (user == null)
             {
                 user = await GetUser();
+
+                // If user is still null after attempting to get the logged in user, return null.
+                if (user == null)
+                {
+                    return null;
+                }
             }
 
             int limit = user.EpisodeRequestLimit ?? 0;

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -615,9 +615,13 @@ namespace Ombi.Core.Engine
             return new RequestEngineResult { Result = true };
         }
 
-        public async Task<RequestQuotaCountModel> GetRemainingRequests()
+        public async Task<RequestQuotaCountModel> GetRemainingRequests(OmbiUser user)
         {
-            OmbiUser user = await GetUser();
+            if (user == null)
+            {
+                user = await GetUser();
+            }
+
             int limit = user.EpisodeRequestLimit ?? 0;
 
             if (limit <= 0)

--- a/src/Ombi.Core/Engine/TvRequestEngine.cs
+++ b/src/Ombi.Core/Engine/TvRequestEngine.cs
@@ -588,6 +588,15 @@ namespace Ombi.Core.Engine
                 NotificationHelper.NewRequest(model);
             }
 
+            await _requestLog.Add(new RequestLog
+            {
+                UserId = (await GetUser()).Id,
+                RequestDate = DateTime.UtcNow,
+                RequestId = model.Id,
+                RequestType = RequestType.TvShow,
+                EpisodeCount = model.SeasonRequests.Select(m => m.Episodes.Count).Sum(),
+            });
+
             if (model.Approved)
             {
                 // Autosend
@@ -602,15 +611,6 @@ namespace Ombi.Core.Engine
                     ErrorMessage = result.Message
                 };
             }
-
-            await _requestLog.Add(new RequestLog
-            {
-                UserId = (await GetUser()).Id,
-                RequestDate = DateTime.UtcNow,
-                RequestId = model.Id,
-                RequestType = RequestType.TvShow,
-                EpisodeCount = model.SeasonRequests.Select(m => m.Episodes.Count).Sum(),
-            });
 
             return new RequestEngineResult { Result = true };
         }

--- a/src/Ombi.Core/Models/UI/UserViewModel.cs
+++ b/src/Ombi.Core/Models/UI/UserViewModel.cs
@@ -16,6 +16,8 @@ namespace Ombi.Core.Models.UI
         public UserType UserType { get; set; }
         public int MovieRequestLimit { get; set; }
         public int EpisodeRequestLimit { get; set; }
+        public RequestQuotaCountModel EpisodeRequestQuota { get; set; }
+        public RequestQuotaCountModel MovieRequestQuota { get; set; }
     }
 
     public class ClaimCheckboxes

--- a/src/Ombi/ClientApp/app/interfaces/IUser.ts
+++ b/src/Ombi/ClientApp/app/interfaces/IUser.ts
@@ -1,4 +1,5 @@
 ﻿import { ICheckbox } from ".";
+import { IRemainingRequests } from "./IRemainingRequests";
 
 export interface IUser {
     id: string;
@@ -13,7 +14,10 @@ export interface IUser {
     movieRequestLimit: number;
     episodeRequestLimit: number;
     userAccessToken: string;
+
     // FOR UI
+    episodeRequestQuota: IRemainingRequests | null;
+    movieRequestQuota: IRemainingRequests | null;
     checked: boolean;
 }
 

--- a/src/Ombi/ClientApp/app/usermanagement/usermanagement-add.component.ts
+++ b/src/Ombi/ClientApp/app/usermanagement/usermanagement-add.component.ts
@@ -32,6 +32,8 @@ export class UserManagementAddComponent implements OnInit {
             episodeRequestLimit: 0,
             movieRequestLimit: 0,
             userAccessToken: "",
+            episodeRequestQuota: null,
+            movieRequestQuota: null,
     };
     }
 

--- a/src/Ombi/ClientApp/app/usermanagement/usermanagement.component.html
+++ b/src/Ombi/ClientApp/app/usermanagement/usermanagement.component.html
@@ -93,18 +93,18 @@
             </td>
             <td class="td-labelled" data-label="Requests Remaining">
                 <div *ngIf="u.movieRequestQuota != null && u.movieRequestQuota.hasLimit">
-                    Movies: {{u.movieRequestQuota.remaining}}/{{u.movieRequestLimit}} remaining
+                    {{'UserManagment.MovieRemaining' | translate: {remaining: u.movieRequestQuota.remaining, total: u.movieRequestLimit} }}
                 </div>
                 <div *ngIf="u.episodeRequestQuota != null && u.episodeRequestQuota.hasLimit">
-                    TV: {{u.episodeRequestQuota.remaining}}/{{u.episodeRequestLimit}} remaining
+                    {{'UserManagment.TvRemaining' | translate: {remaining: u.episodeRequestQuota.remaining, total: u.episodeRequestLimit} }}
                 </div>
             </td>
             <td class="td-labelled" data-label="Request Due">
                 <div *ngIf="u.movieRequestQuota != null && u.movieRequestQuota.remaining != u.movieRequestLimit">
-                    Movie: {{u.movieRequestQuota.nextRequest | date: 'short'}}
+                    {{'UserManagment.MovieDue' | translate: {date: (u.movieRequestQuota.nextRequest | date: 'short')} }}
                 </div>
                 <div *ngIf="u.episodeRequestQuota != null && u.episodeRequestQuota.remaining != u.episodeRequestLimit">
-                    TV: {{u.episodeRequestQuota.nextRequest | date: 'short'}}
+                    {{'UserManagment.TvDue' | translate: {date: (u.episodeRequestQuota.nextRequest | date: 'short')} }}
                 </div>
             </td>
             <td class="td-labelled" data-label="Last Logged In:">

--- a/src/Ombi/ClientApp/app/usermanagement/usermanagement.component.html
+++ b/src/Ombi/ClientApp/app/usermanagement/usermanagement.component.html
@@ -48,6 +48,12 @@
             <th>
                 Roles
             </th>
+            <th>
+                Requests Remaining
+            </th>
+            <th>
+                Next Request Due
+            </th>
             <th (click)="setOrder('lastLoggedIn', $event)">
                <a> Last Logged In</a>
                <span *ngIf="order === 'lastLoggedIn'">
@@ -84,6 +90,22 @@
                     <span *ngIf="claim.enabled">{{claim.value}}</span>
                 </div>
 
+            </td>
+            <td class="td-labelled" data-label="Requests Remaining">
+                <div *ngIf="u.movieRequestQuota != null && u.movieRequestQuota.hasLimit">
+                    Movies: {{u.movieRequestQuota.remaining}}/{{u.movieRequestLimit}} remaining
+                </div>
+                <div *ngIf="u.episodeRequestQuota != null && u.episodeRequestQuota.hasLimit">
+                    TV: {{u.episodeRequestQuota.remaining}}/{{u.episodeRequestLimit}} remaining
+                </div>
+            </td>
+            <td class="td-labelled" data-label="Request Due">
+                <div *ngIf="u.movieRequestQuota != null && u.movieRequestQuota.remaining != u.movieRequestLimit">
+                    Movie: {{u.movieRequestQuota.nextRequest | date: 'short'}}
+                </div>
+                <div *ngIf="u.episodeRequestQuota != null && u.episodeRequestQuota.remaining != u.episodeRequestLimit">
+                    TV: {{u.episodeRequestQuota.nextRequest | date: 'short'}}
+                </div>
             </td>
             <td class="td-labelled" data-label="Last Logged In:">
                 {{u.lastLoggedIn | date: 'short'}}

--- a/src/Ombi/ClientApp/app/usermanagement/usermanagement.module.ts
+++ b/src/Ombi/ClientApp/app/usermanagement/usermanagement.module.ts
@@ -19,6 +19,8 @@ import { AuthGuard } from "../auth/auth.guard";
 import { OrderModule } from "ngx-order-pipe";
 import { AddPlexUserComponent } from "./addplexuser.component";
 
+import { SharedModule } from "../shared/shared.module";
+
 const routes: Routes = [
     { path: "", component: UserManagementComponent, canActivate: [AuthGuard] },
     { path: "add", component: UserManagementAddComponent, canActivate: [AuthGuard] },
@@ -39,6 +41,7 @@ const routes: Routes = [
         TooltipModule,
         OrderModule,
         SidebarModule,
+        SharedModule,
     ],
     declarations: [
         UserManagementComponent,

--- a/src/Ombi/wwwroot/translations/en.json
+++ b/src/Ombi/wwwroot/translations/en.json
@@ -184,5 +184,11 @@
     "FilterHeaderRequestStatus":"Status",
     "Approved":"Approved", 
     "PendingApproval": "Pending Approval"
+  },
+  "UserManagment": {
+    "TvRemaining": "TV: {{remaining}}/{{total}} remaining",
+    "MovieRemaining": "Movies: {{remaining}}/{{total}} remaining",
+    "TvDue": "TV: {{date}}",
+    "MovieDue": "Movie: {{date}}"
   }
 }


### PR DESCRIPTION
Adds information about each users remaining tv/movie quota to the user management page.

Also fixes a bug which would prevent TV requests from being logged if the user requesting has auto approve enabled. This would effectively allow those users to request an infinite number of TV shows.

![image](https://user-images.githubusercontent.com/774415/45116539-f15e8580-b14a-11e8-92be-07f6f8d13835.png)