### PR TITLE
Fixed: Removes Lidarr legacy command result variables

### DIFF
--- a/src/Ombi.Api.Lidarr/Models/CommandResult.cs
+++ b/src/Ombi.Api.Lidarr/Models/CommandResult.cs
@@ -6,10 +6,10 @@ namespace Ombi.Api.Lidarr.Models
     public class CommandResult
     {
         public string name { get; set; }
-        public DateTime startedOn { get; set; }
+        public DateTime queued { get; set; }
         public DateTime stateChangeTime { get; set; }
         public bool sendUpdatesToClient { get; set; }
-        public string state { get; set; }
+        public string status { get; set; }
         public int id { get; set; }
     }
 }


### PR DESCRIPTION
This removes the Sonarr legacy command result variables and changes them to their newer values. These  legacy mappings have been removed in Lidarr (and Sonarr V3 api). 

I know you guys are not using for anything yet, but just wanted to make sure there were not issues down the line.