### PR TITLE
Bug/2564 hide Radarr options when only 1 option available

### DIFF
--- a/src/Ombi/ClientApp/app/requests/movierequests.component.html
+++ b/src/Ombi/ClientApp/app/requests/movierequests.component.html
@@ -129,7 +129,7 @@
                         </form>
 
                         <!--Radarr Root Folder-->
-                        <div *ngIf="radarrRootFolders" class="btn-group btn-split" id="rootFolderBtn">
+                        <div *ngIf="radarrRootFolders?.length > 1" class="btn-group btn-split" id="rootFolderBtn">
                             <button type="button" class="btn btn-sm btn-warning-outline">
                                 <i class="fa fa-plus"></i> {{ 'Requests.ChangeRootFolder' | translate }}
                             </button>
@@ -145,7 +145,7 @@
                         </div>
 
                         <!--Radarr Quality Profiles -->
-                        <div *ngIf="radarrProfiles" class="btn-group btn-split" id="changeQualityBtn">
+                        <div *ngIf="radarrProfiles?.length > 1" class="btn-group btn-split" id="changeQualityBtn">
                             <button type="button" class="btn btn-sm btn-warning-outline">
                                 <i class="fa fa-plus"></i> {{ 'Requests.ChangeQualityProfile' | translate }}
                             </button>


### PR DESCRIPTION
After fixing #2564 I have noticed that Radarr has the same options available. Applying the same fix for consistency.