### PR TITLE
Changes language selector to always show native language name.

### DIFF
--- a/src/Ombi/ClientApp/app/app.component.html
+++ b/src/Ombi/ClientApp/app/app.component.html
@@ -117,37 +117,37 @@
                         </a>
                         <ul class="dropdown-menu" role="menu">
                             <li [ngClass]="{'active': 'en' === translate.currentLang}">
-                                <a (click)="translate.use('en')" [translate]="'NavigationBar.Language.English'"></a>
+                                <a (click)="translate.use('en')">English</a>
                             </li>
                             <li [ngClass]="{'active': 'fr' === translate.currentLang}">
-                                <a (click)="translate.use('fr')" [translate]="'NavigationBar.Language.French'"></a>
+                                <a (click)="translate.use('fr')">Français</a>
                             </li>
                             <li [ngClass]="{'active': 'da' === translate.currentLang}">
-                                <a (click)="translate.use('da')" [translate]="'NavigationBar.Language.Danish'"></a>
+                                <a (click)="translate.use('da')">Dansk</a>
                             </li>
                             <li [ngClass]="{'active': 'de' === translate.currentLang}">
-                                <a (click)="translate.use('de')" [translate]="'NavigationBar.Language.German'"></a>
+                                <a (click)="translate.use('de')">Deutsch</a>
                             </li>
                             <li [ngClass]="{'active': 'it' === translate.currentLang}">
-                                <a (click)="translate.use('it')" [translate]="'NavigationBar.Language.Italian'"></a>
+                                <a (click)="translate.use('it')">Italiano</a>
                             </li>
                             <li [ngClass]="{'active': 'es' === translate.currentLang}">
-                                <a (click)="translate.use('es')" [translate]="'NavigationBar.Language.Spanish'"></a>
+                                <a (click)="translate.use('es')">Español</a>
                             </li>
                             <li [ngClass]="{'active': 'nl' === translate.currentLang}">
-                                <a (click)="translate.use('nl')" [translate]="'NavigationBar.Language.Dutch'"></a>
+                                <a (click)="translate.use('nl')">Nederlands</a>
                             </li>
                             <li [ngClass]="{'active': 'no' === translate.currentLang}">
-                                <a (click)="translate.use('no')" [translate]="'NavigationBar.Language.Norwegian'"></a>
+                                <a (click)="translate.use('no')">Norsk</a>
                             </li>
                             <li [ngClass]="{'active': 'pt' === translate.currentLang}">
-                                <a (click)="translate.use('pt')" [translate]="'NavigationBar.Language.BrazillianPortuguese'"></a>
+                                <a (click)="translate.use('pt')">Português (Brasil)</a>
                             </li>
                             <li [ngClass]="{'active': 'pl' === translate.currentLang}">
-                                <a (click)="translate.use('pl')" [translate]="'NavigationBar.Language.Polish'"></a>
+                                <a (click)="translate.use('pl')">Polski</a>
                             </li>
                             <li [ngClass]="{'active': 'sv' === translate.currentLang}">
-                                <a (click)="translate.use('sv')" [translate]="'NavigationBar.Language.Swedish'"></a>
+                                <a (click)="translate.use('sv')">Svenska</a>
                             </li>
                         </ul>
                     </li>

--- a/src/Ombi/wwwroot/translations/da.json
+++ b/src/Ombi/wwwroot/translations/da.json
@@ -57,19 +57,6 @@
     "Welcome": "Velkommen til {{username}}",
     "UpdateDetails": "Opdater loginoplysninger",
     "Logout": "Log af",
-    "Language": {
-      "English": "Engelsk",
-      "French": "Fransk",
-      "Spanish": "Spansk",
-      "German": "Tysk",
-      "Italian": "Italiensk",
-      "Danish": "Dansk",
-      "Dutch": "Hollandsk",
-      "Norwegian": "Norsk",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish": "Polish",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Åbn mobilapp",
     "RecentlyAdded": "Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/de.json
+++ b/src/Ombi/wwwroot/translations/de.json
@@ -57,19 +57,6 @@
     "Welcome": "Willkommen {{username}}",
     "UpdateDetails": "Update-Details",
     "Logout": "Ausloggen",
-    "Language": {
-      "English": "Englisch",
-      "French": "Französisch",
-      "Spanish": "Spanisch",
-      "German": "Deutsch",
-      "Italian": "Italienisch",
-      "Danish": "Dänisch",
-      "Dutch": "Niederländisch",
-      "Norwegian": "Norwegisch",
-      "BrazillianPortuguese": "Portugiesisch (Brasilien)",
-      "Polish": "Polnisch",
-      "Swedish": "Schwedisch"
-    },
     "OpenMobileApp": "Mobile App",
     "RecentlyAdded": "Kürzlich hinzugefügt"
   },

--- a/src/Ombi/wwwroot/translations/en.json
+++ b/src/Ombi/wwwroot/translations/en.json
@@ -60,19 +60,6 @@
     "Welcome": "Welcome {{username}}",
     "UpdateDetails": "Update Details",
     "Logout": "Logout",
-    "Language": {
-      "English": "English",
-      "French": "French",
-      "Spanish": "Spanish",
-      "German": "German",
-      "Italian": "Italian",
-      "Danish": "Danish",
-      "Dutch": "Dutch",
-      "Norwegian":"Norwegian",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish":"Polish",
-      "Swedish":"Swedish"
-    },
     "OpenMobileApp":"Open Mobile App",
     "RecentlyAdded":"Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/es.json
+++ b/src/Ombi/wwwroot/translations/es.json
@@ -57,19 +57,6 @@
     "Welcome": "Bienvenido {{username}}",
     "UpdateDetails": "Detalles de la actualización",
     "Logout": "Cerrar sesión",
-    "Language": {
-      "English": "Inglés",
-      "French": "Francés",
-      "Spanish": "Español",
-      "German": "Alemán",
-      "Italian": "Italiano",
-      "Danish": "Danés",
-      "Dutch": "Holandés",
-      "Norwegian": "Norwegian",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish": "Polish",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Open Mobile App",
     "RecentlyAdded": "Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/fr.json
+++ b/src/Ombi/wwwroot/translations/fr.json
@@ -57,19 +57,6 @@
     "Welcome": "Bienvenue {{username}}",
     "UpdateDetails": "Détails de la mise à jour",
     "Logout": "Déconnexion",
-    "Language": {
-      "English": "Anglais",
-      "French": "Français",
-      "Spanish": "Espagnol",
-      "German": "Allemand",
-      "Italian": "Italien",
-      "Danish": "Danois",
-      "Dutch": "Néerlandais",
-      "Norwegian": "Norvégien",
-      "BrazillianPortuguese": "Portuguais brésilien",
-      "Polish": "Polonais",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Ouvrir l'application mobile",
     "RecentlyAdded": "Ajouts récents"
   },

--- a/src/Ombi/wwwroot/translations/it.json
+++ b/src/Ombi/wwwroot/translations/it.json
@@ -57,19 +57,6 @@
     "Welcome": "Benvenuto {{username}}",
     "UpdateDetails": "Aggiorna i tuoi dati",
     "Logout": "Logout",
-    "Language": {
-      "English": "Inglese",
-      "French": "Francese",
-      "Spanish": "Spagnolo",
-      "German": "Tedesco",
-      "Italian": "Italiano",
-      "Danish": "Danese",
-      "Dutch": "Olandese",
-      "Norwegian": "Norvegese",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish": "Polish",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Apri l'applicazione mobile",
     "RecentlyAdded": "Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/nl.json
+++ b/src/Ombi/wwwroot/translations/nl.json
@@ -57,19 +57,6 @@
     "Welcome": "Welkom {{username}}",
     "UpdateDetails": "Update gegevens",
     "Logout": "Logout",
-    "Language": {
-      "English": "Engels",
-      "French": "Frans",
-      "Spanish": "Spaans",
-      "German": "Duits",
-      "Italian": "Italiaans",
-      "Danish": "Deens",
-      "Dutch": "Nederlands",
-      "Norwegian": "Noors",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish": "Polish",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Open Mobiele App",
     "RecentlyAdded": "Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/no.json
+++ b/src/Ombi/wwwroot/translations/no.json
@@ -57,19 +57,6 @@
     "Welcome": "Velkommen {{username}}",
     "UpdateDetails": "Oppdater detaljer",
     "Logout": "Logg av",
-    "Language": {
-      "English": "Engelsk",
-      "French": "Fransk",
-      "Spanish": "Spansk",
-      "German": "Tysk",
-      "Italian": "Italiensk",
-      "Danish": "Dansk",
-      "Dutch": "Nederlandsk",
-      "Norwegian": "Norsk",
-      "BrazillianPortuguese": "Brazillian Portuguese",
-      "Polish": "Polish",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Åpne mobilapp",
     "RecentlyAdded": "Recently Added"
   },

--- a/src/Ombi/wwwroot/translations/pl.json
+++ b/src/Ombi/wwwroot/translations/pl.json
@@ -57,19 +57,6 @@
     "Welcome": "Witaj {{username}}",
     "UpdateDetails": "Podaj szczegóły",
     "Logout": "Wyloguj",
-    "Language": {
-      "English": "Angielski",
-      "French": "Francuski",
-      "Spanish": "Hiszpański",
-      "German": "Niemiecki",
-      "Italian": "Włoski",
-      "Danish": "Duński",
-      "Dutch": "Holenderski",
-      "Norwegian": "Norweski",
-      "BrazillianPortuguese": "Brazylijski portugalski",
-      "Polish": "Polski",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Otwórz aplikację mobilną",
     "RecentlyAdded": "Ostatnio dodane"
   },

--- a/src/Ombi/wwwroot/translations/pt.json
+++ b/src/Ombi/wwwroot/translations/pt.json
@@ -57,19 +57,6 @@
     "Welcome": "Bem-vindo, {{username}}",
     "UpdateDetails": "Detalhes da Atualização",
     "Logout": "Sair",
-    "Language": {
-      "English": "Inglês",
-      "French": "Francês",
-      "Spanish": "Espanhol",
-      "German": "Alemão",
-      "Italian": "Italiano",
-      "Danish": "Dinamarquês",
-      "Dutch": "Holandês",
-      "Norwegian": "Norueguês",
-      "BrazillianPortuguese": "Português (Brasil)",
-      "Polish": "Polonês",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Abrir aplicativo do celular",
     "RecentlyAdded": "Recentemente adicionado"
   },

--- a/src/Ombi/wwwroot/translations/sv.json
+++ b/src/Ombi/wwwroot/translations/sv.json
@@ -57,19 +57,6 @@
     "Welcome": "Välkommen {{username}}",
     "UpdateDetails": "Uppdatera information",
     "Logout": "Logga ut",
-    "Language": {
-      "English": "Engelska",
-      "French": "Franska",
-      "Spanish": "Spanska",
-      "German": "Tyska",
-      "Italian": "Italienska",
-      "Danish": "Danska",
-      "Dutch": "Holländska",
-      "Norwegian": "Norska",
-      "BrazillianPortuguese": "Brazillian portugisiska",
-      "Polish": "Polska",
-      "Swedish": "Swedish"
-    },
     "OpenMobileApp": "Öppna Mobil App",
     "RecentlyAdded": "Nyligen tillagda"
   },


### PR DESCRIPTION
This PR is for issue #2407. It restricts language selector to always show native language name. 
I took all native language names from the respective translation files except for Swedish one. I believe that it should Svenska instead. Let me know if you would like this change done differently.