### PR TITLE
Fixes untickable mass email checkboxes in Safari.

### DIFF
--- a/src/Ombi/ClientApp/app/settings/massemail/massemail.component.html
+++ b/src/Ombi/ClientApp/app/settings/massemail/massemail.component.html
@@ -39,7 +39,7 @@
 
             <div class="form-group" *ngFor="let u of users">
                     <div class="checkbox">
-                        <input type="checkbox" id="user{{u.user.id}}" [(ngModel)]="u.selected" (click)="selectSingleUser(u)">
+                        <input type="checkbox" id="user{{u.user.id}}" [(ngModel)]="u.selected">
                         <label for="user{{u.user.id}}">{{u.user.userName}}</label>
                     </div>
                 </div>

--- a/src/Ombi/ClientApp/app/settings/massemail/massemail.component.ts
+++ b/src/Ombi/ClientApp/app/settings/massemail/massemail.component.ts
@@ -38,10 +38,6 @@ export class MassEmailComponent implements OnInit {
         this.users.forEach(u => u.selected = !u.selected);
     }
 
-    public selectSingleUser(user: IMassEmailUserModel) {
-        user.selected = !user.selected;
-    }
-
     public send() {
         if(!this.subject) {
             this.missingSubject = true;


### PR DESCRIPTION
A fix for issues #2298. 

I have noticed that on Safari 'click' trigger was calling to selectSingleUser function after ngModel does the binding, therefore unticking the just ticked checkbox. Since that function was doing nothing other than flipping a boolean value I removed it and left this functionality up to ngModel to handle. 

P.S. Another fix that could have worked in this case is changing 'click' trigger to 'ngModelChange' one. This one seems to be consistent across the browsers.