### PR TITLE
Refactors search bar out of movie/tv/music requests pages into its own component.

### DIFF
--- a/src/Ombi/ClientApp/app/requests/movierequests.component.html
+++ b/src/Ombi/ClientApp/app/requests/movierequests.component.html
@@ -1,48 +1,9 @@
-<div class="form-group">
-    <div class="input-group">
-        <input type="text" id="search" class="form-control form-control-custom searchwidth" placeholder="Search" (keyup)="search($event)">
-        <span class="input-group-btn">
-            <button id="filterBtn" class="btn btn-sm btn-info-outline" (click)="filterDisplay = !filterDisplay">
-                <i class="fa fa-filter"></i> {{ 'Requests.Filter' | translate }}
-            </button>
+<requests-search-bar 
+    [(searchOptions)]="searchOptions" 
+    (searchEvent)="onSearchEvent()">
+</requests-search-bar>
 
-
-            <button class="btn btn-sm btn-primary-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
-                aria-expanded="true">
-                <i class="fa fa-sort"></i> {{ 'Requests.Sort' | translate }}
-                <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                <li>
-                    <a  (click)="setOrder(OrderType.RequestedDateAsc, $event)">{{ 'Requests.SortRequestDateAsc' | translate }}
-           
-                    </a>
-                    <a class="active" (click)="setOrder(OrderType.RequestedDateDesc, $event)">{{ 'Requests.SortRequestDateDesc' | translate }}
-
-                    </a>
-                    <a (click)="setOrder(OrderType.TitleAsc, $event)">{{ 'Requests.SortTitleAsc' | translate}}
-                       
-                    </a>
-                    <a (click)="setOrder(OrderType.TitleDesc, $event)">{{ 'Requests.SortTitleDesc' | translate}}
-                     
-                    </a>
-                    <a (click)="setOrder(OrderType.StatusAsc, $event)">{{ 'Requests.SortStatusAsc' | translate}}
-                
-                    </a>
-                    <a (click)="setOrder(OrderType.StatusDesc, $event)">{{ 'Requests.SortStatusDesc' | translate}}
-              
-                    </a>
-
-                </li>
-            </ul>
-        </span>
-
-    </div>
-
-
-</div>
 <br />
-
 
 <div>
     <div *ngFor="let request of movieRequests">
@@ -207,9 +168,6 @@
         <br/>
         <br/>
 
-
-
-
     </div>
 
     <p-paginator [rows]="10" [totalRecords]="totalMovies" (onPageChange)="paginate($event)"></p-paginator>
@@ -218,48 +176,3 @@
 
 <issue-report [movie]="true" [visible]="issuesBarVisible" (visibleChange)="issuesBarVisible = $event;" [title]="issueRequest?.title"
     [issueCategory]="issueCategorySelected" [id]="issueRequest?.id" [providerId]="issueProviderId"></issue-report>
-
-
-<p-sidebar [(visible)]="filterDisplay" styleClass="ui-sidebar-md side-back side-small">
-    <h3>{{ 'Requests.Filter' | translate }}</h3>
-    <hr>
-    <div>
-        <h4>{{ 'Filter.FilterHeaderAvailability' | translate }}</h4>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="Available" name="Availability" (click)="filterAvailability(filterType.Available, $event)">
-                <label for="Available">{{ 'Common.Available' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="notAvailable" name="Availability" (click)="filterAvailability(filterType.NotAvailable, $event)">
-                <label for="notAvailable">{{ 'Common.NotAvailable' | translate }}</label>
-            </div>
-        </div>
-    </div>
-    <div>
-        <h4>{{ 'Filter.FilterHeaderRequestStatus' | translate }}</h4>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="approved" name="Status" (click)="filterStatus(filterType.Approved, $event)">
-                <label for="approved">{{ 'Filter.Approved' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="Processing" name="Status" (click)="filterStatus(filterType.Processing, $event)">
-                <label for="Processing">{{ 'Common.ProcessingRequest' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="pendingApproval" name="Status" (click)="filterStatus(filterType.PendingApproval, $event)">
-                <label for="pendingApproval">{{ 'Filter.PendingApproval' | translate }}</label>
-            </div>
-        </div>
-    </div>
-
-    <button class="btn btn-sm btn-primary-outline" (click)="clearFilter($event)">
-        <i class="fa fa-filter"></i> {{ 'Filter.ClearFilter' | translate }}</button>
-</p-sidebar>

--- a/src/Ombi/ClientApp/app/requests/movierequests.component.ts
+++ b/src/Ombi/ClientApp/app/requests/movierequests.component.ts
@@ -3,7 +3,7 @@ import { Component, Input, OnInit } from "@angular/core";
 import { DomSanitizer } from "@angular/platform-browser";
 
 import { AuthService } from "../auth/auth.service";
-import { IIssueCategory, IMovieRequests, IPagenator, IRadarrProfile, IRadarrRootFolder, FilterType, OrderType } from "../interfaces";
+import { FilterType, IIssueCategory, IMovieRequests, IPagenator, IRadarrProfile, IRadarrRootFolder, OrderType } from "../interfaces";
 import { NotificationService, RadarrService, RequestService } from "../services";
 import { IRequestSearchModel } from "./search-bar/requests-search-bar.component";
 
@@ -31,9 +31,9 @@ export class MovieRequestsComponent implements OnInit {
         searchText: "",
         filter: {
             availabilityFilter: FilterType.None,
-            statusFilter: FilterType.None
+            statusFilter: FilterType.None,
         },
-        orderType: OrderType.RequestedDateDesc
+        orderType: OrderType.RequestedDateDesc,
     };
 
     public totalMovies: number = 100;

--- a/src/Ombi/ClientApp/app/requests/music/musicrequests.component.html
+++ b/src/Ombi/ClientApp/app/requests/music/musicrequests.component.html
@@ -1,48 +1,9 @@
-<div class="form-group">
-    <div class="input-group">
-        <input type="text" id="search" class="form-control form-control-custom searchwidth" placeholder="Search" (keyup)="search($event)">
-        <span class="input-group-btn">
-            <button id="filterBtn" class="btn btn-sm btn-info-outline" (click)="filterDisplay = !filterDisplay">
-                <i class="fa fa-filter"></i> {{ 'Requests.Filter' | translate }}
-            </button>
+<requests-search-bar 
+    [(searchOptions)]="searchOptions" 
+    (searchEvent)="onSearchEvent()">
+</requests-search-bar>
 
-
-            <button class="btn btn-sm btn-primary-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
-                aria-expanded="true">
-                <i class="fa fa-sort"></i> {{ 'Requests.Sort' | translate }}
-                <span class="caret"></span>
-            </button>
-            <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                <li>
-                    <a  (click)="setOrder(OrderType.RequestedDateAsc, $event)">{{ 'Requests.SortRequestDateAsc' | translate }}
-           
-                    </a>
-                    <a class="active" (click)="setOrder(OrderType.RequestedDateDesc, $event)">{{ 'Requests.SortRequestDateDesc' | translate }}
-
-                    </a>
-                    <a (click)="setOrder(OrderType.TitleAsc, $event)">{{ 'Requests.SortTitleAsc' | translate}}
-                       
-                    </a>
-                    <a (click)="setOrder(OrderType.TitleDesc, $event)">{{ 'Requests.SortTitleDesc' | translate}}
-                     
-                    </a>
-                    <a (click)="setOrder(OrderType.StatusAsc, $event)">{{ 'Requests.SortStatusAsc' | translate}}
-                
-                    </a>
-                    <a (click)="setOrder(OrderType.StatusDesc, $event)">{{ 'Requests.SortStatusDesc' | translate}}
-              
-                    </a>
-
-                </li>
-            </ul>
-        </span>
-
-    </div>
-
-
-</div>
 <br />
-
 
 <div class="col-md-12">
     <div *ngFor="let request of albumRequests"  class="col-md-4">
@@ -220,49 +181,4 @@
 
 
 <issue-report [movie]="true" [visible]="issuesBarVisible" (visibleChange)="issuesBarVisible = $event;" [title]="issueRequest?.title"
-    [issueCategory]="issueCategorySelected" [id]="issueRequest?.id" [providerId]="issueProviderId"></issue-report>
-
-
-<p-sidebar [(visible)]="filterDisplay" styleClass="ui-sidebar-md side-back side-small">
-    <h3>{{ 'Requests.Filter' | translate }}</h3>
-    <hr>
-    <div>
-        <h4>{{ 'Filter.FilterHeaderAvailability' | translate }}</h4>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="Available" name="Availability" (click)="filterAvailability(filterType.Available, $event)">
-                <label for="Available">{{ 'Common.Available' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="notAvailable" name="Availability" (click)="filterAvailability(filterType.NotAvailable, $event)">
-                <label for="notAvailable">{{ 'Common.NotAvailable' | translate }}</label>
-            </div>
-        </div>
-    </div>
-    <div>
-        <h4>{{ 'Filter.FilterHeaderRequestStatus' | translate }}</h4>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="approved" name="Status" (click)="filterStatus(filterType.Approved, $event)">
-                <label for="approved">{{ 'Filter.Approved' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="Processing" name="Status" (click)="filterStatus(filterType.Processing, $event)">
-                <label for="Processing">{{ 'Common.ProcessingRequest' | translate }}</label>
-            </div>
-        </div>
-        <div class="form-group">
-            <div class="radio">
-                <input type="radio" id="pendingApproval" name="Status" (click)="filterStatus(filterType.PendingApproval, $event)">
-                <label for="pendingApproval">{{ 'Filter.PendingApproval' | translate }}</label>
-            </div>
-        </div>
-    </div>
-
-    <button class="btn btn-sm btn-primary-outline" (click)="clearFilter($event)">
-        <i class="fa fa-filter"></i> {{ 'Filter.ClearFilter' | translate }}</button>
-</p-sidebar>
+              [issueCategory]="issueCategorySelected" [id]="issueRequest?.id" [providerId]="issueProviderId"></issue-report>

--- a/src/Ombi/ClientApp/app/requests/music/musicrequests.component.ts
+++ b/src/Ombi/ClientApp/app/requests/music/musicrequests.component.ts
@@ -32,9 +32,9 @@ export class MusicRequestsComponent implements OnInit {
         searchText: "",
         filter: {
             availabilityFilter: FilterType.None,
-            statusFilter: FilterType.None
+            statusFilter: FilterType.None,
         },
-        orderType: OrderType.RequestedDateDesc
+        orderType: OrderType.RequestedDateDesc,
     };
 
     public totalAlbums: number = 100;

--- a/src/Ombi/ClientApp/app/requests/requests.module.ts
+++ b/src/Ombi/ClientApp/app/requests/requests.module.ts
@@ -13,6 +13,7 @@ import { MusicRequestsComponent } from "./music/musicrequests.component";
 import { RequestComponent } from "./request.component";
 import { TvRequestChildrenComponent } from "./tvrequest-children.component";
 import { TvRequestsComponent } from "./tvrequests.component";
+import { RequestsSearchBar } from "./search-bar/requests-search-bar.component";
 
 import { SidebarModule, TooltipModule, TreeTableModule } from "primeng/primeng";
 
@@ -45,6 +46,7 @@ const routes: Routes = [
         TvRequestsComponent,
         TvRequestChildrenComponent,
         MusicRequestsComponent,
+        RequestsSearchBar
     ],
     exports: [
         RouterModule,

--- a/src/Ombi/ClientApp/app/requests/requests.module.ts
+++ b/src/Ombi/ClientApp/app/requests/requests.module.ts
@@ -11,9 +11,9 @@ import { MovieRequestsComponent } from "./movierequests.component";
 import { MusicRequestsComponent } from "./music/musicrequests.component";
 // Request
 import { RequestComponent } from "./request.component";
+import { RequestsSearchBar } from "./search-bar/requests-search-bar.component";
 import { TvRequestChildrenComponent } from "./tvrequest-children.component";
 import { TvRequestsComponent } from "./tvrequests.component";
-import { RequestsSearchBar } from "./search-bar/requests-search-bar.component";
 
 import { SidebarModule, TooltipModule, TreeTableModule } from "primeng/primeng";
 
@@ -46,7 +46,7 @@ const routes: Routes = [
         TvRequestsComponent,
         TvRequestChildrenComponent,
         MusicRequestsComponent,
-        RequestsSearchBar
+        RequestsSearchBar,
     ],
     exports: [
         RouterModule,

--- a/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.html
+++ b/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.html
@@ -1,0 +1,62 @@
+﻿<div class="form-group">
+    <div [ngClass]="{'input-group':showFilter && showSort}" >
+        <input type="text" id="search" class="form-control form-control-custom searchwidth" placeholder="Search" (keyup)="searchOnKeyUp($event)">
+        <span *ngIf="showFilter && showSort" class="input-group-btn">
+
+            <button *ngIf="showFilter" id="filterBtn" class="btn btn-sm btn-info-outline" (click)="isFilterDisplayed = !isFilterDisplayed">
+                <i class="fa fa-filter"></i> {{ 'Requests.Filter' | translate }}
+            </button>
+
+            <button *ngIf="showSort" class="btn btn-sm btn-primary-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                <i class="fa fa-sort"></i> {{ 'Requests.Sort' | translate }}
+                <span class="caret"></span>
+            </button>
+
+            <ul *ngIf="showSort" class="dropdown-menu" aria-labelledby="dropdownMenu2">
+                <li>
+                    <a *ngFor="let sortOption of sortOptions" [ngClass]="{'active':sortOption.isActive}" (click)="setOrderClick(sortOption.orderType)">
+                        {{ sortOption.name | translate }}
+                    </a>
+                </li>
+            </ul>
+        </span>
+    </div>
+</div>
+
+<p-sidebar *ngIf="showFilter" [(visible)]="isFilterDisplayed" styleClass="ui-sidebar-md side-back side-small">
+    <h3>{{ 'Requests.Filter' | translate }}</h3>
+    <hr>
+    <div>
+        <h4>{{ 'Filter.FilterHeaderAvailability' | translate }}</h4>
+        <div class="form-group" *ngFor="let availabilityOption of availabilityFilterOptions">
+            <div class="radio">
+                <input type="radio" 
+                       id={{availabilityOption.id}}
+                       name={{availabilityOption.groupName}}
+                       value={{availabilityOption.filterType}}
+                       [(ngModel)]="searchOptions.filter.availabilityFilter"
+                       (change)="filterOptionsChange()">
+                <label for="{{availabilityOption.id}}">{{ availabilityOption.text | translate }}</label>
+            </div>
+        </div>
+
+    </div>
+    <div>
+        <h4>{{ 'Filter.FilterHeaderRequestStatus' | translate }}</h4>
+        <div class="form-group" *ngFor="let requestStatusOption of requestStatusFilterOptions">
+            <div class="radio">
+                <input type="radio" 
+                       id={{requestStatusOption.id}}
+                       name={{requestStatusOption.groupName}}
+                       value={{requestStatusOption.filterType}}
+                       [(ngModel)]="searchOptions.filter.statusFilter"
+                       (change)="filterOptionsChange()">
+                <label for="{{requestStatusOption.id}}">{{ requestStatusOption.text | translate }}</label>
+            </div>
+        </div>
+    </div>
+
+    <button class="btn btn-sm btn-primary-outline" (click)="clearFilterClick()">
+        <i class="fa fa-filter"></i> {{ 'Filter.ClearFilter' | translate }}
+    </button>
+</p-sidebar>

--- a/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.ts
+++ b/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.ts
@@ -1,0 +1,160 @@
+﻿import { Component, Input, Output, EventEmitter } from "@angular/core";
+import { FilterType, IFilter, OrderType } from "../../interfaces";
+import { Subject } from "rxjs";
+import { debounceTime, distinctUntilChanged } from "rxjs/operators";
+
+export interface IRequestSearchModel {
+    searchText: string,
+    filter: IFilter,
+    orderType: OrderType,
+}
+
+var uniqueRadioButtonId: number = 0;
+
+@Component({
+    selector: "requests-search-bar",
+    templateUrl: "./requests-search-bar.component.html"
+})
+export class RequestsSearchBar {
+    @Input() searchOptions: IRequestSearchModel;
+    @Input() showFilter?: boolean;
+    @Input() showSort?: boolean;
+    @Output() searchEvent = new EventEmitter<IRequestSearchModel>();
+
+    isFilterDisplayed: boolean;
+    sortOptions: Array<{ orderType: OrderType, name: string, isActive: boolean }>;
+    availabilityFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
+    requestStatusFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
+
+    private searchChanged = new Subject<string>();
+
+    constructor() {
+        uniqueRadioButtonId++;
+        this.sortOptions = this.getSortOptions();
+        this.availabilityFilterOptions = this.getAvailabilityFilterOptions();
+        this.requestStatusFilterOptions = this.getRequestStatusFilterOptions();
+
+        this.searchChanged.pipe(
+            debounceTime(600), // Wait Xms after the last event before emitting last event
+            distinctUntilChanged(), // only emit if value is different from previous value
+        ).subscribe((searchText: any) => {
+            this.searchOptions.searchText = searchText as string;
+            this.searchEvent.emit(this.searchOptions);
+        });
+    }
+
+    public ngOnInit() {
+        this.markSelectedSortOptionAsActive();
+        if (this.showFilter === null || this.showFilter === undefined) {
+            this.showFilter = true;
+        }
+        if (this.showSort === null || this.showSort === undefined) {
+            this.showSort = true;
+        }
+    }
+
+    public searchOnKeyUp(searchText: any) {
+        this.searchChanged.next(searchText.target.value);
+    }
+
+    public clearFilterClick() {
+        this.isFilterDisplayed = false;
+        this.searchOptions.filter.availabilityFilter = FilterType.None;
+        this.searchOptions.filter.statusFilter = FilterType.None;
+        this.searchEvent.emit(this.searchOptions);
+    }
+
+    public filterOptionsChange() {
+        this.searchEvent.emit(this.searchOptions);
+    }
+
+    public setOrderClick(value: OrderType) {
+        this.searchOptions.orderType = value;
+        this.markSelectedSortOptionAsActive();
+        this.searchEvent.emit(this.searchOptions);
+    }
+
+    private markSelectedSortOptionAsActive() {
+        this.sortOptions = this.sortOptions.map(option => {
+            option.isActive = option.orderType === this.searchOptions.orderType;
+            return option;
+        });
+    }
+
+    private getAvailabilityFilterOptions() {
+        const groupName = `Availability_${uniqueRadioButtonId}`;
+        return [
+            {
+                groupName: groupName,
+                id: `Available_${uniqueRadioButtonId}`,
+                filterType: FilterType.Available,
+                text: "Common.Available"
+            },
+            {
+                groupName: groupName,
+                id: `NotAvailable_${uniqueRadioButtonId}`,
+                filterType: FilterType.NotAvailable,
+                text: "Common.NotAvailable"
+            }
+        ];
+    }
+
+    private getRequestStatusFilterOptions() {
+        const groupName = `Status_${uniqueRadioButtonId}`;
+        return [
+            {
+                groupName: groupName,
+                id: `Approved_${uniqueRadioButtonId}`,
+                filterType: FilterType.Approved,
+                text: "Filter.Approved"
+            },
+            {
+                groupName: groupName,
+                id: `Processing_${uniqueRadioButtonId}`,
+                filterType: FilterType.Processing,
+                text: "Common.ProcessingRequest"
+            },
+            {
+                groupName: groupName,
+                id: `PendingApproval_${uniqueRadioButtonId}`,
+                filterType: FilterType.PendingApproval,
+                text: "Filter.PendingApproval"
+            }
+        ];
+    }
+
+    private getSortOptions() {
+        return [
+            {
+                isActive: false,
+                name: "Requests.SortRequestDateAsc",
+                orderType: OrderType.RequestedDateAsc
+            },
+            {
+                isActive: false,
+                name: "Requests.SortRequestDateDesc",
+                orderType: OrderType.RequestedDateDesc
+            },
+            {
+                isActive: false,
+                name: "Requests.SortTitleAsc",
+                orderType: OrderType.TitleAsc
+            },
+            {
+                isActive: false,
+                name: "Requests.SortTitleDesc",
+                orderType: OrderType.TitleDesc
+            },
+            {
+                isActive: false,
+                name: "Requests.SortStatusAsc",
+                orderType: OrderType.StatusAsc
+            },
+            {
+                isActive: false,
+                name: "Requests.SortStatusDesc",
+                orderType: OrderType.StatusDesc
+            }
+        ];
+    }
+}

--- a/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.ts
+++ b/src/Ombi/ClientApp/app/requests/search-bar/requests-search-bar.component.ts
@@ -1,30 +1,31 @@
-﻿import { Component, Input, Output, EventEmitter } from "@angular/core";
-import { FilterType, IFilter, OrderType } from "../../interfaces";
+﻿import { Component, EventEmitter, Input, Output } from "@angular/core";
 import { Subject } from "rxjs";
 import { debounceTime, distinctUntilChanged } from "rxjs/operators";
 
+import { FilterType, IFilter, OrderType } from "../../interfaces";
+
 export interface IRequestSearchModel {
-    searchText: string,
-    filter: IFilter,
-    orderType: OrderType,
+    searchText: string;
+    filter: IFilter;
+    orderType: OrderType;
 }
 
-var uniqueRadioButtonId: number = 0;
+let uniqueRadioButtonId: number = 0;
 
 @Component({
     selector: "requests-search-bar",
-    templateUrl: "./requests-search-bar.component.html"
+    templateUrl: "./requests-search-bar.component.html",
 })
 export class RequestsSearchBar {
-    @Input() searchOptions: IRequestSearchModel;
-    @Input() showFilter?: boolean;
-    @Input() showSort?: boolean;
-    @Output() searchEvent = new EventEmitter<IRequestSearchModel>();
+    @Input() public searchOptions: IRequestSearchModel;
+    @Input() public showFilter?: boolean;
+    @Input() public showSort?: boolean;
+    @Output() public searchEvent = new EventEmitter<IRequestSearchModel>();
 
-    isFilterDisplayed: boolean;
-    sortOptions: Array<{ orderType: OrderType, name: string, isActive: boolean }>;
-    availabilityFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
-    requestStatusFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
+    public isFilterDisplayed: boolean;
+    public sortOptions: Array<{ orderType: OrderType, name: string, isActive: boolean }>;
+    public availabilityFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
+    public requestStatusFilterOptions: Array<{ groupName: string, id: string, filterType: FilterType, text: string }>;
 
     private searchChanged = new Subject<string>();
 
@@ -85,17 +86,17 @@ export class RequestsSearchBar {
         const groupName = `Availability_${uniqueRadioButtonId}`;
         return [
             {
-                groupName: groupName,
+                groupName,
                 id: `Available_${uniqueRadioButtonId}`,
                 filterType: FilterType.Available,
-                text: "Common.Available"
+                text: "Common.Available",
             },
             {
-                groupName: groupName,
+                groupName,
                 id: `NotAvailable_${uniqueRadioButtonId}`,
                 filterType: FilterType.NotAvailable,
-                text: "Common.NotAvailable"
-            }
+                text: "Common.NotAvailable",
+            },
         ];
     }
 
@@ -103,23 +104,23 @@ export class RequestsSearchBar {
         const groupName = `Status_${uniqueRadioButtonId}`;
         return [
             {
-                groupName: groupName,
+                groupName,
                 id: `Approved_${uniqueRadioButtonId}`,
                 filterType: FilterType.Approved,
-                text: "Filter.Approved"
+                text: "Filter.Approved",
             },
             {
-                groupName: groupName,
+                groupName,
                 id: `Processing_${uniqueRadioButtonId}`,
                 filterType: FilterType.Processing,
-                text: "Common.ProcessingRequest"
+                text: "Common.ProcessingRequest",
             },
             {
-                groupName: groupName,
+                groupName,
                 id: `PendingApproval_${uniqueRadioButtonId}`,
                 filterType: FilterType.PendingApproval,
-                text: "Filter.PendingApproval"
-            }
+                text: "Filter.PendingApproval",
+            },
         ];
     }
 
@@ -128,33 +129,33 @@ export class RequestsSearchBar {
             {
                 isActive: false,
                 name: "Requests.SortRequestDateAsc",
-                orderType: OrderType.RequestedDateAsc
+                orderType: OrderType.RequestedDateAsc,
             },
             {
                 isActive: false,
                 name: "Requests.SortRequestDateDesc",
-                orderType: OrderType.RequestedDateDesc
+                orderType: OrderType.RequestedDateDesc,
             },
             {
                 isActive: false,
                 name: "Requests.SortTitleAsc",
-                orderType: OrderType.TitleAsc
+                orderType: OrderType.TitleAsc,
             },
             {
                 isActive: false,
                 name: "Requests.SortTitleDesc",
-                orderType: OrderType.TitleDesc
+                orderType: OrderType.TitleDesc,
             },
             {
                 isActive: false,
                 name: "Requests.SortStatusAsc",
-                orderType: OrderType.StatusAsc
+                orderType: OrderType.StatusAsc,
             },
             {
                 isActive: false,
                 name: "Requests.SortStatusDesc",
-                orderType: OrderType.StatusDesc
-            }
+                orderType: OrderType.StatusDesc,
+            },
         ];
     }
 }

--- a/src/Ombi/ClientApp/app/requests/tvrequests.component.html
+++ b/src/Ombi/ClientApp/app/requests/tvrequests.component.html
@@ -1,114 +1,119 @@
-﻿<div class="form-group">
-    <div>
-        <input type="text" id="search" class="form-control form-control-custom" placeholder="Search" (keyup)="search($event)">
-    </div>
-</div>
+﻿<requests-search-bar 
+    [(searchOptions)]="searchOptions"
+    (searchEvent)="onSearchEvent()"
+    [showFilter]="false"
+    [showSort]="false">
+</requests-search-bar>
+
 <br />
 
 <div>
-        <div  *ngFor="let node of tvRequests.collection">
-            <!--This is the section that holds the parent level results set-->
-            <div>
-                <div class="row">
-                    <div class="myBg backdrop" [style.background-image]="node?.background"></div>
-                    <div class="tint" style="background-image: linear-gradient(to bottom, rgba(0,0,0,0.6) 0%,rgba(0,0,0,0.6) 100%);"></div>
+    <div *ngFor="let node of tvRequests.collection">
+        <!--This is the section that holds the parent level results set-->
+        <div>
+            <div class="row">
+                <div class="myBg backdrop" [style.background-image]="node?.background"></div>
+                <div class="tint" style="background-image: linear-gradient(to bottom, rgba(0,0,0,0.6) 0%,rgba(0,0,0,0.6) 100%);"></div>
 
-                    <div class="col-sm-2  small-padding">
+                <div class="col-sm-2  small-padding">
 
-                        <img class="img-responsive poster" src="{{node.posterPath || null}}" alt="poster">
+                    <img class="img-responsive poster" src="{{node.posterPath || null}}" alt="poster">
 
+                </div>
+
+                <div class="col-sm-5 small-padding">
+                    <div>
+                        <a href="http://www.imdb.com/title/{{node.imdbId}}/" target="_blank">
+                            <h4 class="request-title">{{node.title}} ({{node.releaseDate | amLocal | amDateFormat: 'YYYY'}})</h4>
+                        </a>
+                    </div>
+                    <br />
+                    <div>
+                        <span>Status: </span>
+                        <span class="label label-success">{{node.status}}</span>
                     </div>
 
-                    <div class="col-sm-5 small-padding">
-                        <div>
-                            <a href="http://www.imdb.com/title/{{node.imdbId}}/" target="_blank">
-                                <h4 class="request-title">{{node.title}} ({{node.releaseDate | amLocal | amDateFormat: 'YYYY'}})</h4>
-                            </a>
-                        </div>
-                        <br />
-                        <div>
-                            <span>Status: </span>
-                            <span class="label label-success">{{node.status}}</span>
-                        </div>
 
-
-                        <div>Release Date: {{node.releaseDate | amLocal | amDateFormat: 'LL'}}</div>
-                        <div *ngIf="isAdmin">
-                            <div *ngIf="node.qualityOverrideTitle" class="quality-override">{{ 'Requests.QualityOverride' | translate }}
-                                <span>{{node.qualityOverrideTitle}} </span>
-                            </div>
-                            <div *ngIf="node.rootPathOverrideTitle" class="root-override">{{ 'Requests.RootFolderOverride' | translate }}
-                                <span>{{node.rootPathOverrideTitle}} </span>
-                            </div>
+                    <div>Release Date: {{node.releaseDate | amLocal | amDateFormat: 'LL'}}</div>
+                    <div *ngIf="isAdmin">
+                        <div *ngIf="node.qualityOverrideTitle" class="quality-override">
+                            {{ 'Requests.QualityOverride' | translate }}
+                            <span>{{node.qualityOverrideTitle}} </span>
                         </div>
-
-                        <br />
+                        <div *ngIf="node.rootPathOverrideTitle" class="root-override">
+                            {{ 'Requests.RootFolderOverride' | translate }}
+                            <span>{{node.rootPathOverrideTitle}} </span>
+                        </div>
                     </div>
-                    <div class="col-sm-3 col-sm-push-3  small-padding">
 
-                        <button style="text-align: right" class="btn btn-sm btn-success-outline" (click)="openClosestTab(node,$event)">
-                            <i class="fa fa-plus"></i> View</button>
-                        <div *ngIf="isAdmin">
-                            <!--Sonarr Root Folder-->
-                            <div *ngIf="sonarrRootFolders?.length > 1" class="btn-group btn-split" id="rootFolderBtn">
-                                <button type="button" class="btn btn-sm btn-warning-outline">
-                                    <i class="fa fa-plus"></i> {{ 'Requests.ChangeRootFolder' | translate }}
-                                </button>
-                                <button type="button" class="btn btn-warning-outline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="caret"></span>
-                                    <span class="sr-only">Toggle Dropdown</span>
-                                </button>
-                                <ul class="dropdown-menu">
-                                    <li *ngFor="let folder of sonarrRootFolders">
-                                        <a href="#" (click)="selectRootFolder(node, folder, $event)">{{folder.path}}</a>
-                                    </li>
-                                </ul>
-                            </div>
+                    <br />
+                </div>
+                <div class="col-sm-3 col-sm-push-3  small-padding">
 
-                            <!--Sonarr Quality Profiles -->
-                            <div *ngIf="sonarrProfiles?.length > 1" class="btn-group btn-split" id="changeQualityBtn">
-                                <button type="button" class="btn btn-sm btn-warning-outline">
-                                    <i class="fa fa-plus"></i> {{ 'Requests.ChangeQualityProfile' | translate }}
-                                </button>
-                                <button type="button" class="btn btn-warning-outline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                                    <span class="caret"></span>
-                                    <span class="sr-only">Toggle Dropdown</span>
-                                </button>
-                                <ul class="dropdown-menu">
-                                    <li *ngFor="let profile of sonarrProfiles">
-                                        <a href="#" (click)="selectQualityProfile(node, profile, $event)">{{profile.name}}</a>
-                                    </li>
-                                </ul>
-                            </div>
-
-                        </div>
-                        <div class="dropdown" *ngIf="issueCategories && issuesEnabled" id="issueBtn">
-                            <button class="btn btn-sm btn-primary-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
-                                aria-expanded="true">
-                                <i class="fa fa-plus"></i> {{ 'Requests.ReportIssue' | translate }}
-                                <span class="caret"></span>
+                    <button style="text-align: right" class="btn btn-sm btn-success-outline" (click)="openClosestTab(node,$event)">
+                        <i class="fa fa-plus"></i> View
+                    </button>
+                    <div *ngIf="isAdmin">
+                        <!--Sonarr Root Folder-->
+                        <div *ngIf="sonarrRootFolders?.length > 1" class="btn-group btn-split" id="rootFolderBtn">
+                            <button type="button" class="btn btn-sm btn-warning-outline">
+                                <i class="fa fa-plus"></i> {{ 'Requests.ChangeRootFolder' | translate }}
                             </button>
-                            <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
-                                <li *ngFor="let cat of issueCategories">
-                                    <a [routerLink]="" (click)="reportIssue(cat, node)">{{cat.value}}</a>
+                            <button type="button" class="btn btn-warning-outline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="caret"></span>
+                                <span class="sr-only">Toggle Dropdown</span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li *ngFor="let folder of sonarrRootFolders">
+                                    <a href="#" (click)="selectRootFolder(node, folder, $event)">{{folder.path}}</a>
                                 </li>
                             </ul>
                         </div>
+
+                        <!--Sonarr Quality Profiles -->
+                        <div *ngIf="sonarrProfiles?.length > 1" class="btn-group btn-split" id="changeQualityBtn">
+                            <button type="button" class="btn btn-sm btn-warning-outline">
+                                <i class="fa fa-plus"></i> {{ 'Requests.ChangeQualityProfile' | translate }}
+                            </button>
+                            <button type="button" class="btn btn-warning-outline dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="caret"></span>
+                                <span class="sr-only">Toggle Dropdown</span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li *ngFor="let profile of sonarrProfiles">
+                                    <a href="#" (click)="selectQualityProfile(node, profile, $event)">{{profile.name}}</a>
+                                </li>
+                            </ul>
+                        </div>
+
+                    </div>
+                    <div class="dropdown" *ngIf="issueCategories && issuesEnabled" id="issueBtn">
+                        <button class="btn btn-sm btn-primary-outline dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true"
+                                aria-expanded="true">
+                            <i class="fa fa-plus"></i> {{ 'Requests.ReportIssue' | translate }}
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+                            <li *ngFor="let cat of issueCategories">
+                                <a [routerLink]="" (click)="reportIssue(cat, node)">{{cat.value}}</a>
+                            </li>
+                        </ul>
                     </div>
                 </div>
             </div>
-            <!--This is the section that holds the child seasons if they want to specify specific episodes-->
-            <div *ngIf="node.open">
-                <tvrequests-children [childRequests]="node.childRequests" [isAdmin]="isAdmin" [currentUser]="currentUser" (requestDeleted)="childRequestDeleted($event)"></tvrequests-children>
-            </div>
-            
-        <br/>
-        <br/>
-
         </div>
+        <!--This is the section that holds the child seasons if they want to specify specific episodes-->
+        <div *ngIf="node.open">
+            <tvrequests-children [childRequests]="node.childRequests" [isAdmin]="isAdmin" [currentUser]="currentUser" (requestDeleted)="childRequestDeleted($event)"></tvrequests-children>
+        </div>
+
+        <br />
+        <br />
+
+    </div>
 
     <p-paginator [rows]="10" [totalRecords]="totalTv" (onPageChange)="paginate($event)"></p-paginator>
 </div>
 
 <issue-report [movie]="false" [visible]="issuesBarVisible" [title]="issueRequest?.title" [issueCategory]="issueCategorySelected"
-    [id]="issueRequest?.id" [providerId]="issueProviderId" (visibleChange)="issuesBarVisible = $event;"></issue-report>
+              [id]="issueRequest?.id" [providerId]="issueProviderId" (visibleChange)="issuesBarVisible = $event;"></issue-report>

--- a/src/Ombi/ClientApp/app/requests/tvrequests.component.ts
+++ b/src/Ombi/ClientApp/app/requests/tvrequests.component.ts
@@ -38,9 +38,9 @@ export class TvRequestsComponent implements OnInit {
         searchText: "",
         filter: {
             availabilityFilter: FilterType.None,
-            statusFilter: FilterType.None
+            statusFilter: FilterType.None,
         },
-        orderType: OrderType.RequestedDateDesc
+        orderType: OrderType.RequestedDateDesc,
     };
 
     public totalTv: number = 100;


### PR DESCRIPTION
Hi. I have noticed that search bar has been duplicated (html and ts) across multiple requests pages. So as a good learning exercise, I have extracted it out into its own component. 

I'm still just learning Angular, so please let me know what should be done differently.

These changes should not have affected any current behavior, except for one of issues I have noticed while testing. Filter check-boxes are not being selected properly on movies and music pages due to names and ids being the same for both pages.

A few other issues I have noticed (but not fixed) while being in this area:
1. If search returns more than 10 results and user clicks on page 2, Ombi shows simply page two as if no search has happened.
1. `Status` sorting is not supported for music requests on server side (error 500), but is an option on client side.
1. Searching ignores selected filters and sorting option.
1. `Filter` and `Sort` buttons look weird on desktop (and mobile kinda too) at btn-sm size. 