### PR TITLE
Maps alias email variable for welcome emails.

### DIFF
--- a/src/Ombi/Controllers/IdentityController.cs
+++ b/src/Ombi/Controllers/IdentityController.cs
@@ -863,6 +863,7 @@ namespace Ombi.Controllers
         {
             var ombiUser = new OmbiUser
             {
+                Alias = user.Alias,
                 Email = user.EmailAddress,
                 UserName = user.UserName
             };


### PR DESCRIPTION
Fix for #2658. Looks like user's alias property hasn't been mapped at controller level.