### PR TITLE
Fix cake build by setting Incubator version

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 #addin "Cake.Gulp"
 #addin "SharpZipLib"
 #addin nuget:?package=Cake.Compression&version=0.1.4
-#addin "Cake.Incubator"
+#addin "Cake.Incubator&version=3.1.0"
 #addin "Cake.Yarn"
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Since the last time the CI passed, 2 versions have been released: [Cake.Incubator releases](https://github.com/cake-contrib/Cake.Incubator/releases)

Downgrading Cake.Incubator fixes the build.