### PR TITLE
Update EmbyURL. Fixes #3078

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v3.0.4680 (2019-07-17)
+
+
+### **Fixes**
+
+- Fixed the database lock issues - [TidusJar]
+- Fixed the issue with [Plex OAuth](https://forums.plex.tv/t/plex-oauth-not-working-with-tautulli-ombi-etc/433945) - [TidusJar]
+
 ## v3.0.4659 (2019-07-02)
 
 ### **New Features**

--- a/src/Ombi.Helpers/EmbyHelper.cs
+++ b/src/Ombi.Helpers/EmbyHelper.cs
@@ -11,11 +11,11 @@ namespace Ombi.Helpers
         {
             if (customerServerUrl.HasValue())
             {
-                return $"{customerServerUrl}#!/itemdetails.html?id={mediaId}";
+                return $"{customerServerUrl}#!/item/item.html?id={mediaId}";
             }
             else
             {
-                return $"https://app.emby.media/#!/itemdetails.html?id={mediaId}";
+                return $"https://app.emby.media/#!/item/item.html?id={mediaId}";
             }
         }
     }

--- a/src/Ombi/ClientApp/app/settings/emby/emby.component.html
+++ b/src/Ombi/ClientApp/app/settings/emby/emby.component.html
@@ -71,8 +71,8 @@
                                 </label>
                                 <div>
                                     <input type="text" class="form-control-custom form-control" id="authToken" [(ngModel)]="server.serverHostname" placeholder="e.g. https://jellyfin.server.com/" value="{{server.serverHostname}}">
-                                    <small><span *ngIf="server.serverHostname">Current URL: "{{server.serverHostname}}/#!/itemdetails.html?id=1"</span>
-                                    <span *ngIf="!server.serverHostname">Current URL: "https://app.emby.media/#!/itemdetails.html?id=1</span></small>
+                                    <small><span *ngIf="server.serverHostname">Current URL: "{{server.serverHostname}}/#!/item/item.html?id=1"</span>
+                                    <span *ngIf="!server.serverHostname">Current URL: "https://app.emby.media/#!/item/item.html?id=1</span></small>
                                 </div>
                             </div>
                             <div class="form-group">


### PR DESCRIPTION
Update EmbyURL. Fixes #3078
Emby changed the URL starting with the Emby version v4.2.0

Note: This will probably break support for Jellyfin.