### PR TITLE
Fixes issue #3195

### DIFF
--- a/.github/.github/workflows/test.workflow
+++ b/.github/.github/workflows/test.workflow
@@ -1,9 +1,0 @@
-workflow "New workflow" {
-  on = "push"
-  resolves = [".NET Core CLI"]
-}
-
-action ".NET Core CLI" {
-  uses = "baruchiro/github-actions@0.0.1"
-  args = "build src/Ombi.sln"
-}

--- a/.github/.github/workflows/test.workflow
+++ b/.github/.github/workflows/test.workflow
@@ -1,0 +1,9 @@
+workflow "New workflow" {
+  on = "push"
+  resolves = [".NET Core CLI"]
+}
+
+action ".NET Core CLI" {
+  uses = "baruchiro/github-actions@0.0.1"
+  args = "build src/Ombi.sln"
+}

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -1,0 +1,17 @@
+name: ASP.NET Core CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.108
+    - name: Build with dotnet
+      run: dotnet build --configuration Release

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -15,5 +15,3 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build src/Ombi.sln --configuration Release
-    - name: Run Tests
-      run: dotnet test src/Ombi.sln

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -13,5 +13,12 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 2.2.108
-    - name: Build with dotnet
+    
+    - name: Build Backend
       run: dotnet build src/Ombi.sln --configuration Release
+     
+     - name: Install Yarn
+       uses: nuxt/actions-yarn@master
+     
+     - name: Build Frontend
+       run: yarn --cdw src/Ombi/ build

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -17,8 +17,8 @@ jobs:
     - name: Build Backend
       run: dotnet build src/Ombi.sln --configuration Release
      
-     - name: Install Yarn
-       uses: nuxt/actions-yarn@master
+    - name: Install Yarn
+      uses: nuxt/actions-yarn@master
      
-     - name: Build Frontend
-       run: yarn --cdw src/Ombi/ build
+    - name: Build Frontend
+      run: yarn --cdw src/Ombi/ build

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -1,6 +1,6 @@
 name: ASP.NET Core CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -14,4 +14,4 @@ jobs:
       with:
         dotnet-version: 2.2.108
     - name: Build with dotnet
-      run: dotnet build --configuration Release
+      run: dotnet build src/Ombi.sln --configuration Release

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -16,4 +16,4 @@ jobs:
     - name: Build with dotnet
       run: dotnet build src/Ombi.sln --configuration Release
     - name: Run Tests
-      run: dotnet test src/Ombi.sln --no-build
+      run: dotnet test src/Ombi.sln

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -15,3 +15,5 @@ jobs:
         dotnet-version: 2.2.108
     - name: Build with dotnet
       run: dotnet build src/Ombi.sln --configuration Release
+    - name: Run Tests
+      run: dotnet test src/Ombi.sln --no-build

--- a/.github/workflows/aspnetcore.yml
+++ b/.github/workflows/aspnetcore.yml
@@ -15,10 +15,4 @@ jobs:
         dotnet-version: 2.2.108
     
     - name: Build Backend
-      run: dotnet build src/Ombi.sln --configuration Release
-     
-    - name: Install Yarn
-      uses: nuxt/actions-yarn@master
-     
-    - name: Build Frontend
-      run: yarn --cdw src/Ombi/ build
+      run: ./build.sh --settings_skipverification=true

--- a/.github/workflows/test.workflow
+++ b/.github/workflows/test.workflow
@@ -1,0 +1,9 @@
+workflow "New workflow" {
+  on = "push"
+  resolves = [".NET Core CLI"]
+}
+
+action ".NET Core CLI" {
+  uses = "baruchiro/github-actions@0.0.1"
+  args = "build src/Ombi.sln"
+}

--- a/src/Ombi.Core/Engine/MusicSearchEngine.cs
+++ b/src/Ombi.Core/Engine/MusicSearchEngine.cs
@@ -17,6 +17,7 @@ using Ombi.Api.Lidarr.Models;
 using Ombi.Core.Authentication;
 using Ombi.Core.Settings;
 using Ombi.Helpers;
+using Ombi.Core.Helpers;
 using Ombi.Settings.Settings.Models;
 using Ombi.Settings.Settings.Models.External;
 using Ombi.Store.Entities;
@@ -166,7 +167,7 @@ namespace Ombi.Core.Engine
                 Rating = a.ratings?.value ?? 0m,
                 ReleaseDate = a.releaseDate,
                 Title = a.title,
-                Disk = a.images?.FirstOrDefault(x => x.coverType.Equals("disc"))?.url?.Replace("http", "https"),
+                Disk = a.images?.FirstOrDefault(x => x.coverType.Equals("disc"))?.url?.ToHttpsUrl(),
                 Genres = a.genres,
                 AlbumType = a.albumType,
                 ArtistName = a.artist.artistName,
@@ -187,7 +188,7 @@ namespace Ombi.Core.Engine
                 //vm.ArtistName = a.artist?.artistName;
             }
 
-            vm.Cover = a.images?.FirstOrDefault(x => x.coverType.Equals("cover"))?.url?.Replace("http", "https");
+            vm.Cover = a.images?.FirstOrDefault(x => x.coverType.Equals("cover"))?.url?.ToHttpsUrl();
 
             await Rules.StartSpecificRules(vm, SpecificRules.LidarrAlbum);
 
@@ -205,7 +206,7 @@ namespace Ombi.Core.Engine
                 Rating = a.ratings?.value ?? 0m,
                 ReleaseDate = a.releaseDate,
                 Title = a.title,
-                Disk = a.images?.FirstOrDefault(x => x.coverType.Equals("disc"))?.url?.Replace("http", "https"),
+                Disk = a.images?.FirstOrDefault(x => x.coverType.Equals("disc"))?.url?.ToHttpsUrl(),
                 Genres = a.genres
             };
             if (a.artistId > 0)
@@ -223,7 +224,7 @@ namespace Ombi.Core.Engine
                 vm.ArtistName = a.artist?.artistName;
             }
 
-            vm.Cover = a.images?.FirstOrDefault(x => x.coverType.Equals("cover"))?.url?.Replace("http", "https");
+            vm.Cover = a.images?.FirstOrDefault(x => x.coverType.Equals("cover"))?.url?.ToHttpsUrl();
             if (vm.Cover.IsNullOrEmpty())
             {
                 vm.Cover = a.remoteCover;

--- a/src/Ombi.Helpers.Tests/StringHelperTests.cs
+++ b/src/Ombi.Helpers.Tests/StringHelperTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+
+namespace Ombi.Helpers.Tests
+{
+    [TestFixture]
+    public class StringHelperTests
+    {
+        [Test]
+        public void ToHttpsUrl_ShouldReturnsHttpsUrl_HttpUrl()
+        {
+            var sourceUrl = "http://www.test.url";
+            var expectedUrl = "https://www.test.url";
+
+            Assert.AreEqual(expectedUrl, sourceUrl.ToHttpsUrl(), "Should return the source URL as https");
+        }
+
+        [Test]
+        public void ToHttpsUrl_ShouldReturnsUnchangedUrl_HttpsUrl()
+        {
+            var sourceUrl = "https://www.test.url";
+            var expectedUrl = "https://www.test.url";
+
+            Assert.AreEqual(expectedUrl, sourceUrl.ToHttpsUrl(), "Should return the unchanged https URL");
+        }
+
+        [Test]
+        public void ToHttpsUrl_ShouldReturnsUnchangedUrl_NonHttpUrl()
+        {
+            var sourceUrl = "ftp://www.test.url";
+            var expectedUrl = "ftp://www.test.url";
+
+            Assert.AreEqual(expectedUrl, sourceUrl.ToHttpsUrl(), "Should return the unchanged non-http URL");
+        }
+
+        [Test]
+        public void ToHttpsUrl_ShouldReturnsUnchangedUrl_InvalidUrl()
+        {
+            var sourceUrl = "http:/www.test.url";
+            var expectedUrl = "http:/www.test.url";
+
+            Assert.AreEqual(expectedUrl, sourceUrl.ToHttpsUrl(), "Should return the unchanged invalid URL");
+        }
+    }
+}

--- a/src/Ombi.Helpers/StringHelper.cs
+++ b/src/Ombi.Helpers/StringHelper.cs
@@ -128,5 +128,10 @@ namespace Ombi.Helpers
         {
             return string.Concat(str.Where(c => !chars.Contains(c)));
         }
+
+        public static string ToHttpsUrl(this string currentUrl)
+        {
+            return currentUrl.Replace("http://", "https://");
+        }
     }
 }

--- a/src/Ombi.Mapping/Profiles/TvProfile.cs
+++ b/src/Ombi.Mapping/Profiles/TvProfile.cs
@@ -29,7 +29,7 @@ namespace Ombi.Mapping.Profiles
                 .ForMember(dest => dest.Runtime, opts => opts.MapFrom(src => src.show.runtime.ToString()))
                 .ForMember(dest => dest.SeriesId, opts => opts.MapFrom(src => src.show.id))
                 .ForMember(dest => dest.Title, opts => opts.MapFrom(src => src.show.name))
-                .ForMember(dest => dest.Banner, opts => opts.MapFrom(src => !string.IsNullOrEmpty(src.show.image.medium) ? src.show.image.medium.Replace("http", "https") : string.Empty))
+                .ForMember(dest => dest.Banner, opts => opts.MapFrom(src => !string.IsNullOrEmpty(src.show.image.medium) ? src.show.image.medium.ToHttpsUrl() : string.Empty))
                 .ForMember(dest => dest.Status, opts => opts.MapFrom(src => src.show.status));
 
             CreateMap<TvMazeShow, SearchTvShowViewModel>()
@@ -46,7 +46,7 @@ namespace Ombi.Mapping.Profiles
                 .ForMember(dest => dest.Title, opts => opts.MapFrom(src => src.name))
                 .ForMember(dest => dest.Banner,
                     opts => opts.MapFrom(src => !string.IsNullOrEmpty(src.image.medium)
-                        ? src.image.medium.Replace("http", "https")
+                        ? src.image.medium.ToHttpsUrl()
                         : string.Empty))
                 .ForMember(dest => dest.Status, opts => opts.MapFrom(src => src.status));
 

--- a/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
+++ b/src/Ombi.Schedule/Jobs/Ombi/NewsletterJob.cs
@@ -682,7 +682,7 @@ namespace Ombi.Schedule.Jobs.Ombi
                     var banner = info.image?.original;
                     if (!string.IsNullOrEmpty(banner))
                     {
-                        banner = banner.Replace("http", "https"); // Always use the Https banners
+                        banner = banner.ToHttpsUrl(); // Always use the Https banners
                     }
                     
                     var tvInfo = await _movieApi.GetTVInfo(t.TheMovieDbId);
@@ -804,7 +804,7 @@ namespace Ombi.Schedule.Jobs.Ombi
                     var banner = info.image?.original;
                     if (!string.IsNullOrEmpty(banner))
                     {
-                        banner = banner.Replace("http", "https"); // Always use the Https banners
+                        banner = banner.ToHttpsUrl(); // Always use the Https banners
                     }
 
                     var tvInfo = await _movieApi.GetTVInfo(t.TheMovieDbId);


### PR DESCRIPTION
The new string extension method ToHttpsUrl ensures that URLs starting with "https" are no longer turned into "httpss"
The commit also replaces all occurances of the error prone .Replace("http", "https") in the whole solution.