### PR TITLE
Fixes issue #3153

### DIFF
--- a/src/Ombi.Notifications/Agents/SlackNotification.cs
+++ b/src/Ombi.Notifications/Agents/SlackNotification.cs
@@ -79,7 +79,7 @@ namespace Ombi.Notifications.Agents
 
         protected override async Task RequestDeclined(NotificationOptions model, SlackNotificationSettings settings)
         {
-            await Run(model, settings, NotificationType.RequestAvailable);
+            await Run(model, settings, NotificationType.RequestDeclined);
         }
 
         protected override async Task RequestApproved(NotificationOptions model, SlackNotificationSettings settings)


### PR DESCRIPTION
It looks like the Slack notification agent was using the wrong notification type in the request declined method.