### PR TITLE
Fix search bar overlap on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## (unreleased)
+## v3.0.4817  (2019-10-15)
 
 ### **New Features**
 

--- a/src/Ombi/ClientApp/app/search/moviesearch.component.html
+++ b/src/Ombi/ClientApp/app/search/moviesearch.component.html
@@ -1,30 +1,41 @@
 ﻿<!-- Movie tab -->
 <div role="tabpanel" class="tab-pane active" id="MoviesTab">
 
-    <div class="input-group search-bar-background">
-        <input id="search" type="text" placeholder="{{ 'Search.SearchBarPlaceholder' | translate}}" class="form-control form-control-custom form-control-search form-control-withbuttons"
-            (keyup)="search($event)">
-        <div class="input-group-addon right-radius">
-            <div class="btn-group" role="group">
-                <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                    {{ 'Search.Suggestions' | translate }}
-                    <i class="fa fa-chevron-down"></i>
-                </a>
-                <ul class="dropdown-menu">
-                    <li><a (click)="popularMovies()" [translate]="'Search.Movies.PopularMovies'"></a></li>
-                    <li><a (click)="upcomingMovies()" [translate]="'Search.Movies.UpcomingMovies'"></a></li>
-                    <li><a (click)="topRatedMovies()" [translate]="'Search.Movies.TopRatedMovies'"></a></li>
-                    <li><a (click)="nowPlayingMovies()" [translate]="'Search.Movies.NowPlayingMovies'"></a></li>
-                </ul>
-                <button class="btn btn-sm btn-primary-outline" (click)="refineOpen()">
-                    {{ 'Search.Refine' | translate }}
-                    <i class="fa" [ngClass]="{'fa-chevron-down': !refineSearchEnabled, 'fa-chevron-up': refineSearchEnabled}"></i>
-                </button>
-            </div>
+    <ng-template #FilterRef>
+        <div class="btn-group" role="group">
+            <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                {{ 'Search.Suggestions' | translate }}
+                <i class="fa fa-chevron-down"></i>
+            </a>
+            <ul class="dropdown-menu">
+                <li><a (click)="popularMovies()" [translate]="'Search.Movies.PopularMovies'"></a></li>
+                <li><a (click)="upcomingMovies()" [translate]="'Search.Movies.UpcomingMovies'"></a></li>
+                <li><a (click)="topRatedMovies()" [translate]="'Search.Movies.TopRatedMovies'"></a></li>
+                <li><a (click)="nowPlayingMovies()" [translate]="'Search.Movies.NowPlayingMovies'"></a></li>
+            </ul>
+            <button class="btn btn-sm btn-primary-outline" (click)="refineOpen()">
+                {{ 'Search.Refine' | translate }}
+                <i class="fa" [ngClass]="{'fa-chevron-down': !refineSearchEnabled, 'fa-chevron-up': refineSearchEnabled}"></i>
+            </button>
+        </div>
+    </ng-template>
 
+    <div class="input-group search-bar-background">
+        <input id="search" type="text" placeholder="{{ 'Search.SearchBarPlaceholder' | translate}}"
+               class="form-control form-control-custom form-control-search form-control-withbuttons"
+               (keyup)="search($event)">
+        <div class="input-group-addon right-radius">
+            <div class="search-button-container-inline">
+                <ng-template [ngTemplateOutlet]="FilterRef"></ng-template>
+            </div>
             <i class="fa fa-search"></i>
         </div>
     </div>
+
+    <div class="row search-button-container">
+        <ng-template [ngTemplateOutlet]="FilterRef"></ng-template>
+    </div>
+
     <!-- Refine search options -->
     <div class="row top-spacing form-group vcenter" *ngIf="refineSearchEnabled">
         <div class="col-md-1">

--- a/src/Ombi/ClientApp/app/search/search.component.scss
+++ b/src/Ombi/ClientApp/app/search/search.component.scss
@@ -3,7 +3,7 @@
         padding-top: 5%
     }    
     .form-control-search {
-        width: 77%;
+        padding-right: 165px;
     }
 
 }

--- a/src/Ombi/ClientApp/app/search/tvsearch.component.html
+++ b/src/Ombi/ClientApp/app/search/tvsearch.component.html
@@ -1,30 +1,42 @@
 ﻿<!-- Movie tab -->
 <div role="tabpanel" class="tab-pane" id="TvShowTab">
+    <ng-template #FilterRef>
+        <div class="btn-group" role="group">
+            <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+                {{ 'Search.Suggestions' | translate }}
+                <i class="fa fa-chevron-down"></i>
+            </a>
+            <ul class="dropdown-menu">
+                <li>
+                    <a (click)="popularShows()">{{ 'Search.TvShows.Popular' | translate }} </a>
+                </li>
+                <li>
+                    <a (click)="trendingShows()">{{ 'Search.TvShows.Trending' | translate }}</a>
+                </li>
+                <li>
+                    <a (click)="mostWatchedShows()">{{ 'Search.TvShows.MostWatched' | translate }}</a>
+                </li>
+                <li>
+                    <a (click)="anticipatedShows()">{{ 'Search.TvShows.MostAnticipated' | translate }}</a>
+                </li>
+            </ul>
+        </div>
+    </ng-template>
+
     <div class="input-group">
-        <input id="search" type="text" placeholder="{{ 'Search.SearchBarPlaceholder' | translate }}" class="form-control form-control-custom form-control-search form-control-withbuttons" (keyup)="search($event)">
+        <input id="search" type="text" placeholder="{{ 'Search.SearchBarPlaceholder' | translate }}"
+               class="form-control form-control-custom form-control-search form-control-withbuttons"
+               (keyup)="search($event)">
         <div class="input-group-addon right-radius">
-            <div class="btn-group">
-                <a href="#" class="btn btn-sm btn-primary-outline dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                    {{ 'Search.Suggestions' | translate }}
-                    <i class="fa fa-chevron-down"></i>
-                </a>
-                <ul class="dropdown-menu">
-                    <li>
-                        <a (click)="popularShows()">{{ 'Search.TvShows.Popular' | translate }} </a>
-                    </li>
-                    <li>
-                        <a (click)="trendingShows()">{{ 'Search.TvShows.Trending' | translate }}</a>
-                    </li>
-                    <li>
-                        <a (click)="mostWatchedShows()">{{ 'Search.TvShows.MostWatched' | translate }}</a>
-                    </li>
-                    <li>
-                        <a (click)="anticipatedShows()">{{ 'Search.TvShows.MostAnticipated' | translate }}</a>
-                    </li>
-                </ul>
+            <div class="search-button-container-inline">
+                <ng-template [ngTemplateOutlet]="FilterRef"></ng-template>
             </div>
             <i id="tvSearchButton" class="fa fa-search"></i>
         </div>
+    </div>
+
+    <div class="row search-button-container">
+        <ng-template [ngTemplateOutlet]="FilterRef"></ng-template>
     </div>
 
     <remaining-requests [tv]="true" [quotaRefreshEvents]="tvRequested.asObservable()" #remainingTvShows></remaining-requests>
@@ -159,6 +171,7 @@
                 <br/>
                 <br/>
             </div>
+        </div>
     </div>
 </div>
 

--- a/src/Ombi/ClientApp/styles/base.scss
+++ b/src/Ombi/ClientApp/styles/base.scss
@@ -389,6 +389,27 @@ $border-radius: 10px;
     padding-right: 105px;
 }
 
+.search-button-container {
+    margin-top: 10px;
+    text-align: center;
+}
+
+@media (max-width: 450px) {
+    .form-control-search {
+        padding-right: 0 !important;
+    }
+
+    .search-button-container-inline {
+        display: none;
+    }
+}
+
+@media (min-width: 450px) {
+    .search-button-container {
+        display: none;
+    }
+}
+
 .input-group-addon .btn-group {
     position: absolute;
     right: 45px;


### PR DESCRIPTION
Fixes the "Suggestions" and "Refine" buttons overlapping the search bar on mobile devices (specifically phones) in portrait mode. The alternative view is only present when the width is 450px or less.

Before            |  After
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/715687/67153229-0349ac00-f2ab-11e9-91a7-cc373de67b26.jpg" height="300" /> | <img src="https://user-images.githubusercontent.com/715687/67153230-0349ac00-f2ab-11e9-8613-132e50208542.jpg" height="300" />

Ignore the "TV Shows" tab missing from the "Before" as I have it hidden on my prod server. Also ignore the icons missing from the "After" as I'm not sure why they don't show up in my local environment (any pointers on fixing this?).
