### PR TITLE
Add RequestId variable in notification's data

### DIFF
--- a/src/Ombi.Core/Engine/Demo/DemoTvSearchEngine.cs
+++ b/src/Ombi.Core/Engine/Demo/DemoTvSearchEngine.cs
@@ -56,7 +56,7 @@ namespace Ombi.Core.Engine.Demo
                     {
                         continue;
                     }
-                    retVal.Add(ProcessResult(tvMazeSearch));
+                    retVal.Add(await ProcessResult(tvMazeSearch));
                 }
                 return retVal;
             }
@@ -78,7 +78,7 @@ namespace Ombi.Core.Engine.Demo
                 }
 
                 var movieResult = await TvMazeApi.ShowLookup(tv);
-                responses.Add(ProcessResult(movieResult));
+                responses.Add(await ProcessResult(movieResult));
             }
 
             return responses;

--- a/src/Ombi.Core/Engine/TvSearchEngine.cs
+++ b/src/Ombi.Core/Engine/TvSearchEngine.cs
@@ -61,7 +61,7 @@ namespace Ombi.Core.Engine
                     {
                         continue;
                     }
-                    retVal.Add(ProcessResult(tvMazeSearch));
+                    retVal.Add(await ProcessResult(tvMazeSearch));
                 }
                 return retVal;
             }
@@ -123,7 +123,7 @@ namespace Ombi.Core.Engine
         public async Task<IEnumerable<SearchTvShowViewModel>> Popular()
         {
             var result = await Cache.GetOrAdd(CacheKeys.PopularTv, async () => await TraktApi.GetPopularShows(), DateTime.Now.AddHours(12));
-            var processed = ProcessResults(result);
+            var processed = await ProcessResults(result);
             return processed;
         }
 
@@ -131,37 +131,38 @@ namespace Ombi.Core.Engine
         {
 
             var result = await Cache.GetOrAdd(CacheKeys.AnticipatedTv, async () => await TraktApi.GetAnticipatedShows(), DateTime.Now.AddHours(12));
-            var processed = ProcessResults(result);
+            var processed = await ProcessResults(result);
             return processed;
         }
 
         public async Task<IEnumerable<SearchTvShowViewModel>> MostWatches()
         {
             var result = await Cache.GetOrAdd(CacheKeys.MostWatchesTv, async () => await TraktApi.GetMostWatchesShows(), DateTime.Now.AddHours(12));
-            var processed = ProcessResults(result);
+            var processed = await ProcessResults(result);
             return processed;
         }
 
         public async Task<IEnumerable<SearchTvShowViewModel>> Trending()
         {
             var result = await Cache.GetOrAdd(CacheKeys.TrendingTv, async () => await TraktApi.GetTrendingShows(), DateTime.Now.AddHours(12));
-            var processed = ProcessResults(result);
+            var processed = await ProcessResults(result);
             return processed;
         }
 
-        protected IEnumerable<SearchTvShowViewModel> ProcessResults<T>(IEnumerable<T> items)
+        protected async Task<IEnumerable<SearchTvShowViewModel>> ProcessResults<T>(IEnumerable<T> items)
         {
             var retVal = new List<SearchTvShowViewModel>();
             foreach (var tvMazeSearch in items)
             {
-                retVal.Add(ProcessResult(tvMazeSearch));
+                retVal.Add(await ProcessResult(tvMazeSearch));
             }
             return retVal;
         }
 
-        protected SearchTvShowViewModel ProcessResult<T>(T tvMazeSearch)
+        protected async Task<SearchTvShowViewModel> ProcessResult<T>(T tvMazeSearch)
         {
-            return Mapper.Map<SearchTvShowViewModel>(tvMazeSearch);
+            var viewTv = Mapper.Map<SearchTvShowViewModel>(tvMazeSearch);
+            return await ProcessResult(viewTv);
         }
 
         private async Task<SearchTvShowViewModel> ProcessResult(SearchTvShowViewModel item)

--- a/src/Ombi.Core/Models/Search/SearchViewModel.cs
+++ b/src/Ombi.Core/Models/Search/SearchViewModel.cs
@@ -7,6 +7,8 @@ namespace Ombi.Core.Models.Search
     {
         public int Id { get; set; }
         public bool Approved { get; set; }
+        public bool? Denied { get; set; }
+        public string DeniedReason { get; set; }
         public bool Requested { get; set; }
         public int RequestId { get; set; }
         public bool Available { get; set; }

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -63,7 +63,6 @@ namespace Ombi.Core.Rule.Rules.Search
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
                     request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
-                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.DeniedReason != null)?.DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)

--- a/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
+++ b/src/Ombi.Core/Rule/Rules/Search/ExistingRule.cs
@@ -34,6 +34,8 @@ namespace Ombi.Core.Rule.Rules.Search
                     obj.Requested = true;
                     obj.RequestId = movieRequests.Id;
                     obj.Approved = movieRequests.Approved;
+                    obj.Denied = movieRequests.Denied ?? false;
+                    obj.DeniedReason = movieRequests.DeniedReason;
                     obj.Available = movieRequests.Available;
 
                     return Success();
@@ -60,6 +62,8 @@ namespace Ombi.Core.Rule.Rules.Search
 
                     request.Requested = true;
                     request.Approved = tvRequests.ChildRequests.Any(x => x.Approved);
+                    request.Denied = tvRequests.ChildRequests.Any(x => x.Denied ?? false);
+                    request.DeniedReason = tvRequests.ChildRequests.FirstOrDefault(x => x.DeniedReason != null)?.DeniedReason;
 
                     // Let's modify the seasonsrequested to reflect what we have requested...
                     foreach (var season in request.SeasonRequests)
@@ -108,6 +112,8 @@ namespace Ombi.Core.Rule.Rules.Search
                     obj.Requested = true;
                     obj.RequestId = albumRequest.Id;
                     obj.Approved = albumRequest.Approved;
+                    obj.Denied = albumRequest.Denied;
+                    obj.DeniedReason = albumRequest.DeniedReason;
                     obj.Available = albumRequest.Available;
 
                     return Success();

--- a/src/Ombi.Notifications/NotificationMessageCurlys.cs
+++ b/src/Ombi.Notifications/NotificationMessageCurlys.cs
@@ -119,7 +119,7 @@ namespace Ombi.Notifications
         {
             LoadIssues(opts);
 
-            RequestId = req?.Id.ToString();
+            RequestId = req?.ParentRequestId.ToString();
 
             string title;
             if (req == null)

--- a/src/Ombi.Notifications/NotificationMessageCurlys.cs
+++ b/src/Ombi.Notifications/NotificationMessageCurlys.cs
@@ -18,6 +18,8 @@ namespace Ombi.Notifications
         {
             LoadIssues(opts);
 
+            RequestId = req?.Id.ToString();
+
             string title;
             if (req == null)
             {
@@ -68,6 +70,8 @@ namespace Ombi.Notifications
         {
             LoadIssues(opts);
 
+            RequestId = req?.Id.ToString();
+
             string title;
             if (req == null)
             {
@@ -114,6 +118,9 @@ namespace Ombi.Notifications
         public void Setup(NotificationOptions opts, ChildRequests req, CustomizationSettings s, UserNotificationPreferences pref)
         {
             LoadIssues(opts);
+
+            RequestId = req?.Id.ToString();
+
             string title;
             if (req == null)
             {
@@ -216,6 +223,7 @@ namespace Ombi.Notifications
         }
 
         // User Defined
+        public string RequestId { get; set; }
         public string RequestedUser { get; set; }
         public string UserName { get; set; }
         public string IssueUser => UserName;
@@ -248,6 +256,7 @@ namespace Ombi.Notifications
 
         public Dictionary<string, string> Curlys => new Dictionary<string, string>
         {
+            {nameof(RequestId), RequestId },
             {nameof(RequestedUser), RequestedUser },
             {nameof(Title), Title },
             {nameof(RequestedDate), RequestedDate },


### PR DESCRIPTION
Just adding the `RequestId` property into the notification's data. I believe this would essentially help for the Webhook kind. For instance, in my case, this will allow me to easily keep track of a request from a Telegram bot.