### PR TITLE
Fix Open Graph metadata

### DIFF
--- a/src/Ombi/Views/Shared/_Layout.cshtml
+++ b/src/Ombi/Views/Shared/_Layout.cshtml
@@ -79,12 +79,13 @@
     <meta name="description" content="Ombi, media request tool">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@appName</title>
-    <meta property="og:title" content="@appName" />
-    <meta property="og:image" content="~/images/logo.png" />
-    <meta property="og:image:width" content="991" />
     <meta property="og:image:height" content="375" />
-    <meta property="og:type" content="website" />
+    <meta property="og:image:width" content="991" />
+    <meta property="og:image" content="~/images/logo.png" />
     <meta property="og:site_name" content="@appName" />
+    <meta property="og:title" content="@appName" />
+    <meta property="og:type" content="website" />
+    <meta property="og:description" content="Ombi, media request tool">
     @{
         if (customization.ApplicationUrl.HasValue())
         {

--- a/src/Ombi/Views/Shared/_Layout.cshtml
+++ b/src/Ombi/Views/Shared/_Layout.cshtml
@@ -88,7 +88,7 @@
     @{
         if (customization.ApplicationUrl.HasValue())
         {
-           <meta property="og:url" content="customization.ApplicationUrl" />
+           <meta property="og:url" content="@customization.ApplicationUrl" />
         }
     }
     <base href="/@baseUrl" />

--- a/src/Ombi/Views/Shared/_Layout.cshtml
+++ b/src/Ombi/Views/Shared/_Layout.cshtml
@@ -1,4 +1,4 @@
-﻿@using Ombi.Core.Settings
+@using Ombi.Core.Settings
 @using Ombi.Helpers
 @using Ombi.Settings.Settings.Models
 @inject ISettingsService<OmbiSettings> Settings
@@ -79,9 +79,18 @@
     <meta name="description" content="Ombi, media request tool">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@appName</title>
-    <meta property="og:title" content=“@appName” />
+    <meta property="og:title" content="@appName" />
     <meta property="og:image" content="~/images/logo.png" />
-    <meta property="og:site_name" content=“@appName” />
+    <meta property="og:image:width" content="991" />
+    <meta property="og:image:height" content="375" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="@appName" />
+    @{
+        if (customization.ApplicationUrl.HasValue())
+        {
+           <meta property="og:url" content="customization.ApplicationUrl" />
+        }
+    }
     <base href="/@baseUrl" />
     <link rel="apple-touch-icon" sizes="180x180" href="~/images/favicon/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="~/images/favicon/favicon-32x32.png">


### PR DESCRIPTION
The Open Graph title and site name had curly quotes that caused the Open Graph tags to fail to parse. This broke previews on Facebook, Twitter, LinkedIn and, most importantly to me, Apple's iMessage.

This PR fixes those quotes and improves upon the existing Open Graph metadata by setting most of the minimum required tags for proper display on all above mentioned platforms. The [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/) is useful for determining what the Open Graph tags will render as on Facebook as well as ensure proper implementation against the [Open Graph spec](https://ogp.me/).

Please note, while I am a professional web developer I did not validate this change locally as I didn't want to have to setup a whole environment for this one change. I believe it will work fine though.