### PR TITLE
Replace smartquotes in meta info

### DIFF
--- a/src/Ombi/Views/Shared/_Layout.cshtml
+++ b/src/Ombi/Views/Shared/_Layout.cshtml
@@ -78,7 +78,7 @@
     <meta name="description" content="Ombi, media request tool">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@appName</title>
-    <meta property="og:title" content=“@appName” />
+    <meta property="og:title" content="@appName" />
     <meta property="og:image" content="~/images/logo.png" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">


### PR DESCRIPTION
With the smartquotes, only the first word of the custom app gets loaded in inside apps that use those tags for previews.

For example, my Ombi instance has the name set as "Bloom Plex Requests" but when sent via iMessage, the preview only shows "Bloom as the title.