### PR TITLE
Create tidusjar/Ombi pre-release tags

### DIFF
--- a/.azuredevops/pipelines/publish-job.yml
+++ b/.azuredevops/pipelines/publish-job.yml
@@ -70,7 +70,7 @@ stages:
         target: '$(Build.SourceVersion)'
         tagSource: 'userSpecifiedTag'
         tag: '$(gitTag)'
-        isDraft: true
+        isPreRelease: true
         changeLogCompareToRelease: 'lastNonDraftRelease'
         changeLogType: 'commitBased'
 


### PR DESCRIPTION
isDraft creates unpublished tags, which are not publicly visible. This
change publishes the tags as pre-release github releases with tags.

Fixes tidusjar/Ombi#3587

Signed-off-by: Joe Groocock <me@frebib.net>