### PR TITLE
settings textbox width fix

### DIFF
--- a/src/Ombi/ClientApp/src/styles/material-overrides.scss
+++ b/src/Ombi/ClientApp/src/styles/material-overrides.scss
@@ -9,3 +9,7 @@
 td.mat-cell {
     padding: 0.75rem !important;
 }
+
+.mat-form-field {
+    display: block !important;
+}


### PR DESCRIPTION
this makes the text entry boxes in the settings pages fill their element instead of being so narrow.

![image](https://user-images.githubusercontent.com/6140137/92060116-9ae7aa00-ed58-11ea-919e-dfdd2dc38869.png)

vs OLD

![image](https://user-images.githubusercontent.com/6140137/92060170-b81c7880-ed58-11ea-99d1-edbbd65209eb.png)

IM LEARNING!