### PR TITLE
Cleanup console output during startup.

### DIFF
--- a/src/Ombi.Store/Context/Sqlite/ExternalSqliteContext.cs
+++ b/src/Ombi.Store/Context/Sqlite/ExternalSqliteContext.cs
@@ -24,7 +24,7 @@ namespace Ombi.Store.Context.Sqlite
         {
             try
             {
-                Database.ExecuteSqlCommand(@"INSERT INTO __EFMigrationsHistory (MigrationId,ProductVersion)
+                Database.ExecuteSqlRaw(@"INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId,ProductVersion)
                 VALUES('20191103205133_Inital', '2.2.6-servicing-10079'); ");
             }
             catch (Exception)

--- a/src/Ombi.Store/Context/Sqlite/OmbiSqliteContext.cs
+++ b/src/Ombi.Store/Context/Sqlite/OmbiSqliteContext.cs
@@ -22,7 +22,7 @@ namespace Ombi.Store.Context.Sqlite
         {
             try
             {
-                Database.ExecuteSqlCommand(@"INSERT INTO __EFMigrationsHistory (MigrationId,ProductVersion)
+                Database.ExecuteSqlRaw(@"INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId,ProductVersion)
                 VALUES('20191102235658_Inital', '2.2.6-servicing-10079'); ");
             }
             catch (Exception)

--- a/src/Ombi.Store/Context/Sqlite/SettingsSqliteContext.cs
+++ b/src/Ombi.Store/Context/Sqlite/SettingsSqliteContext.cs
@@ -20,7 +20,7 @@ namespace Ombi.Store.Context.Sqlite
         {
             try
             {
-                Database.ExecuteSqlCommand(@"INSERT INTO __EFMigrationsHistory (MigrationId,ProductVersion)
+                Database.ExecuteSqlRaw(@"INSERT OR IGNORE INTO __EFMigrationsHistory (MigrationId,ProductVersion)
                 VALUES('20191103205204_Inital', '2.2.6-servicing-10079'); ");
             }
             catch (Exception) 

--- a/src/Ombi/Program.cs
+++ b/src/Ombi/Program.cs
@@ -96,6 +96,10 @@ namespace Ombi
 
                     urlValue = url.Value;
                 }
+                else if (string.IsNullOrEmpty(urlValue))
+                {
+                    urlValue = host;
+                }
 
                 if (dbBaseUrl == null)
                 {


### PR DESCRIPTION
This pull requests fixes:
* Console output for url+port in use.
* SQLite unique constrain exception.
  > Note: ExecuteSqlCommand is now marked as obsolete so I changed it to ExecuteSqlRaw.