### PR TITLE
Fix WebKit windowing effect

### DIFF
--- a/src/Ombi/ClientApp/src/styles/shared.scss
+++ b/src/Ombi/ClientApp/src/styles/shared.scss
@@ -38,7 +38,7 @@
 html,
 body {
     min-height: 100vh;
-    overflow: auto;
+    overflow: initial;
     scrollbar-color: #616161 #303030; //firefox
     scrollbar-width: thin; //firefox
     -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
At the moment, as of 9e0986ce9fcb62df20fe22c7c6dcee70445d7694. the `overflow` css property is set to `auto`. This causes a windowing effect on MobileKit devices (iOS, iPadOS).

![IMG_0058](https://user-images.githubusercontent.com/13283054/96087105-a2f04900-0ec3-11eb-8c37-21c500498571.jpg)

After setting the `overflow` property to `initial`(Which is the default, this will actually set to: `visible`) the following outcome is observed:

![IMG_0057](https://user-images.githubusercontent.com/13283054/96087148-b3a0bf00-0ec3-11eb-8937-3a47a8d8e04e.jpg)

I have tested this property on all the devices as I have on hand:
 - Safari (MacOS)
 - Chromium (MacOS)
 - Firefox (MacOS)

And it doesn't break anything as far as I can see. Happy to open a discussion if this implementation is non-standard