### PR TITLE
Fixed: Don't Type RadarrAddMovieResponse Image list to String

### DIFF
--- a/src/Ombi.Api.Radarr/Models/RadarrAddMovie.cs
+++ b/src/Ombi.Api.Radarr/Models/RadarrAddMovie.cs
@@ -7,7 +7,7 @@ namespace Ombi.Api.Radarr.Models
 
         public RadarrAddMovieResponse()
         {
-            images = new List<string>();
+            images = new List<Image>();
         }
         public RadarrError Error { get; set; }
         public RadarrAddOptions addOptions { get; set; }
@@ -16,7 +16,7 @@ namespace Ombi.Api.Radarr.Models
         public int qualityProfileId { get; set; }
         public bool monitored { get; set; }
         public int tmdbId { get; set; }
-        public List<string> images { get; set; }
+        public List<Image> images { get; set; }
         public string titleSlug { get; set; }
         public int year { get; set; }
         public string minimumAvailability { get; set; }


### PR DESCRIPTION
In both the v2 and v3 Radarr API responses, the images property of a movie is a list of Image objects. This has never been a list of strings and causes errors with Ombi V3 and Radarr V3 given V3 returns all metadata on add, V2 always returned an empty list on a movie add (of the same image object as V3). 

It seems this has been an issue since the beginning in Ombi, but wasn't noticed with V2. 

Option 2 just remove it given its not used anyway, we are getting user complaints for those that don't want to use v4 due to bugs... can we please backport this and release, its a couple lines.